### PR TITLE
Rename: wsh-upon-star → @johnhenry/wsh (restart at 0.0.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - run: npm test
       - run: npm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.0.0
+
+- **Renamed: `wsh-upon-star` is now `@johnhenry/wsh`, restarting at 0.0.0.**
+  Same library, same API — a shorter name, a new address, a new version era.
+  Previously published as `wsh-upon-star` (last release 0.1.1), now
+  deprecated. The GitHub repo moved to `github.com/johnhenry/wsh` (the old
+  path redirects).
+
+  ```sh
+  npm install @johnhenry/wsh
+  ```
+
+  Docs: https://opensource.johnhenry.me/wsh/. The 0.0.0 is a deliberate
+  restart on import, not a maturity signal.
+
+
 ## 0.1.0 (2026-03-15)
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # wsh-upon-star
 
+> Previously published as `wsh-upon-star` (last release: 0.1.1, now deprecated).
+> Renamed to `@johnhenry/wsh` and restarted at 0.0.0 on import into the
+> @johnhenry family — a new name and era, not a maturity signal.
+
 Browser-native remote command execution over WebTransport/WebSocket with Ed25519 authentication.
 
 wsh-upon-star is a pure-JS client library that connects browsers to remote shells. It implements its own binary protocol (CBOR over length-prefixed frames) with Ed25519 challenge-response auth, channel multiplexing, session management, and MCP tool bridging.
@@ -7,14 +11,14 @@ wsh-upon-star is a pure-JS client library that connects browsers to remote shell
 ## Install
 
 ```bash
-npm install wsh-upon-star
+npm install @johnhenry/wsh
 ```
 
 Or via CDN:
 
 ```html
 <script type="module">
-  import { WshClient, generateKeyPair } from 'https://esm.sh/wsh-upon-star';
+  import { WshClient, generateKeyPair } from 'https://esm.sh/@johnhenry/wsh';
 </script>
 ```
 
@@ -34,7 +38,7 @@ Or via CDN:
 ## Quick Start
 
 ```js
-import { WshClient, generateKeyPair } from 'wsh-upon-star';
+import { WshClient, generateKeyPair } from '@johnhenry/wsh';
 
 // Generate an Ed25519 key pair
 const keyPair = await generateKeyPair(true);
@@ -75,7 +79,7 @@ await client.disconnect();
 ## One-Shot Command Execution
 
 ```js
-import { WshClient, generateKeyPair } from 'wsh-upon-star';
+import { WshClient, generateKeyPair } from '@johnhenry/wsh';
 
 const keyPair = await generateKeyPair(true);
 const { stdout, exitCode } = await WshClient.exec(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "wsh-upon-star",
-  "version": "0.1.1",
-  "description": "Web Shell — browser-native remote command execution over WebTransport and WebSocket with Ed25519 authentication",
+  "name": "@johnhenry/wsh",
+  "version": "0.0.0",
+  "description": "Web Shell \u2014 browser-native remote command execution over WebTransport and WebSocket with Ed25519 authentication",
   "type": "module",
   "main": "./src/index.mjs",
   "exports": {
@@ -32,10 +32,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/johnhenry/wsh-upon-star"
+    "url": "git+https://github.com/johnhenry/wsh.git"
   },
   "author": "John Henry",
   "engines": {
     "node": ">=24.0.0"
-  }
+  },
+  "homepage": "https://opensource.johnhenry.me/wsh/"
 }


### PR DESCRIPTION
Third adopt-library run, and the first **base-name change** (not just scoping): `wsh-upon-star` → `@johnhenry/wsh`, GitHub repo renamed to match.

- Version restart to 0.0.0 with provenance notes (agent-query precedent)
- All install/import/esm.sh references + repo-path references updated; 278/278 tests pass
- No bin, so the `wsh` name collision with the unrelated unscoped `wsh` package (webshell.io) doesn't matter — it's only a scoped package name
- Fixed publish.yml Node 22 → 24 to match `engines` and CI

**Do not release until John sets a scope-capable NPM_TOKEN** (same blocker as http-fields/ecmanim). Docs section to follow on opensource.johnhenry.me.