### PR TITLE
docs: add runnable examples with CI smoke step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm test
+      - name: Examples smoke test
+        run: npm run examples

--- a/examples/01-frames-survive-fragmented-transport.mjs
+++ b/examples/01-frames-survive-fragmented-transport.mjs
@@ -1,0 +1,71 @@
+/**
+ * Frames survive a fragmented transport.
+ *
+ * The wsh wire format is length-prefixed CBOR: [4-byte be32 length][CBOR payload]
+ * (see spec/wsh-v1.md, "Transport Bindings"). A real network delivers bytes in
+ * arbitrary chunks, so the FrameDecoder must reassemble frames no matter how
+ * the stream is sliced. This example encodes a batch of protocol messages,
+ * shreds the byte stream into awkward fragments, and shows every message
+ * arrives intact and in order.
+ */
+
+import assert from 'node:assert/strict';
+import {
+  frameEncode, FrameDecoder,
+  MSG, hello, ping, open, sessionData, exit, msgName,
+} from '@johnhenry/wsh';
+
+// ── Encode a realistic message sequence ───────────────────────────────
+
+const outgoing = [
+  hello({ username: 'demo', features: ['mcp'], authMethod: 'pubkey' }),
+  open({ kind: 'exec', command: 'uname -a', cols: 80, rows: 24 }),
+  sessionData({ channelId: 1, data: new TextEncoder().encode('Linux wsh 6.1\n') }),
+  ping({ id: 7 }),
+  exit({ channelId: 1, code: 0 }),
+];
+
+// Concatenate all frames into one continuous byte stream, as a transport would.
+const frames = outgoing.map(frameEncode);
+const stream = new Uint8Array(frames.reduce((n, f) => n + f.length, 0));
+let offset = 0;
+for (const f of frames) { stream.set(f, offset); offset += f.length; }
+
+console.log(`encoded ${outgoing.length} messages into ${stream.length} bytes`);
+
+// Spec check: every frame starts with a be32 length prefix.
+const firstLen = new DataView(frames[0].buffer).getUint32(0);
+assert.equal(firstLen, frames[0].length - 4);
+console.log(`first frame: ${firstLen}-byte CBOR payload after 4-byte be32 prefix`);
+
+// ── Deliver the stream in hostile fragment sizes ──────────────────────
+
+// Worst cases: 1-byte drips (splits every length prefix) and a split that
+// lands mid-payload.
+for (const chunkSize of [1, 3, 5, 1024]) {
+  const decoder = new FrameDecoder();
+  const received = [];
+  for (let i = 0; i < stream.length; i += chunkSize) {
+    received.push(...decoder.feed(stream.subarray(i, i + chunkSize)));
+  }
+
+  assert.equal(received.length, outgoing.length);
+  assert.equal(decoder.pending, 0); // no leftover bytes
+  assert.equal(received[0].type, MSG.HELLO);
+  assert.equal(received[0].username, 'demo');
+  assert.equal(received[4].type, MSG.EXIT);
+  assert.equal(received[4].code, 0);
+  console.log(
+    `chunk size ${String(chunkSize).padStart(4)}: ` +
+    `${received.length}/${outgoing.length} messages reassembled ` +
+    `(${received.map((m) => msgName(m.type)).join(' → ')})`
+  );
+}
+
+// Binary payloads survive too: SESSION_DATA carries raw bytes.
+const decoder = new FrameDecoder();
+const [roundTripped] = decoder.feed(frameEncode(outgoing[2]));
+assert.equal(new TextDecoder().decode(roundTripped.data), 'Linux wsh 6.1\n');
+console.log('binary SESSION_DATA payload round-tripped byte-for-byte');
+
+console.log('ok: frames survive fragmented delivery');

--- a/examples/02-tampered-challenge-fails-authentication.mjs
+++ b/examples/02-tampered-challenge-fails-authentication.mjs
@@ -1,0 +1,78 @@
+/**
+ * A tampered challenge fails authentication.
+ *
+ * wsh authenticates clients with an Ed25519 challenge-response (spec/wsh-v1.md,
+ * "Crypto Primitives"): the server sends a random nonce, the client signs the
+ * transcript SHA-256("wsh-v1\0" || session_id || nonce || channel_binding),
+ * and the server verifies the signature against the client's public key.
+ *
+ * Signing the *transcript* — not the bare nonce — binds the signature to this
+ * protocol version and this session, so a signature can never be replayed
+ * against a different session or spliced into another connection. This example
+ * runs the whole flow in-process (no network) and shows exactly which
+ * manipulations make verification fail.
+ */
+
+import assert from 'node:assert/strict';
+import {
+  generateKeyPair, exportPublicKeyRaw, exportPublicKeySSH,
+  importPublicKeyRaw, signChallenge, verifyChallenge,
+  fingerprint, shortFingerprint, generateNonce, parseSSHPublicKey,
+} from '@johnhenry/wsh';
+
+// ── Client: generate an identity ──────────────────────────────────────
+
+const { publicKey, privateKey } = await generateKeyPair();
+const sshKey = await exportPublicKeySSH(publicKey);
+const raw = await exportPublicKeyRaw(publicKey);
+const fp = await fingerprint(raw);
+
+console.log('client identity:');
+console.log(`  ${sshKey.slice(0, 40)}... (authorized_keys format)`);
+console.log(`  fingerprint ${shortFingerprint(fp)}… (${fp.length}-char hex)`);
+
+// The SSH-format key parses back to the same 32 raw bytes the server stores.
+const parsed = parseSSHPublicKey(sshKey);
+assert.ok(parsed, 'SSH key line parses');
+
+// ── Server: issue a challenge ─────────────────────────────────────────
+
+const sessionId = 'sess-42';
+const nonce = generateNonce(); // 32 random bytes
+console.log(`server challenge: session "${sessionId}", ${nonce.length}-byte nonce`);
+
+// ── Client: sign the transcript ───────────────────────────────────────
+
+const { signature, publicKeyRaw } = await signChallenge(
+  privateKey, publicKey, sessionId, nonce
+);
+console.log(`client response: ${signature.length}-byte signature + ${publicKeyRaw.length}-byte public key`);
+
+// ── Server: verify ────────────────────────────────────────────────────
+
+// The server imports the raw key the client sent (after checking it against
+// authorized keys) and verifies the transcript signature.
+const serverSideKey = await importPublicKeyRaw(publicKeyRaw);
+
+const genuine = await verifyChallenge(serverSideKey, signature, sessionId, nonce);
+assert.equal(genuine, true);
+console.log('genuine response:            verified ✓');
+
+// Tampering 1: replay against a different session — transcript changes, fails.
+const replayed = await verifyChallenge(serverSideKey, signature, 'sess-43', nonce);
+assert.equal(replayed, false);
+console.log('same signature, other session: rejected ✓');
+
+// Tampering 2: stale/forged nonce — fails.
+const forgedNonce = await verifyChallenge(serverSideKey, signature, sessionId, generateNonce());
+assert.equal(forgedNonce, false);
+console.log('same signature, fresh nonce:   rejected ✓');
+
+// Tampering 3: a different key pair claiming the same identity — fails.
+const impostor = await generateKeyPair();
+const impostorSig = await signChallenge(impostor.privateKey, impostor.publicKey, sessionId, nonce);
+const impostorOk = await verifyChallenge(serverSideKey, impostorSig.signature, sessionId, nonce);
+assert.equal(impostorOk, false);
+console.log('impostor key pair:             rejected ✓');
+
+console.log('ok: only the untampered challenge-response authenticates');

--- a/examples/03-handshake-to-exec-over-in-process-pipe.mjs
+++ b/examples/03-handshake-to-exec-over-in-process-pipe.mjs
@@ -1,0 +1,125 @@
+/**
+ * Handshake to exec over an in-process pipe.
+ *
+ * A complete wsh conversation — HELLO → SERVER_HELLO → CHALLENGE → AUTH →
+ * AUTH_OK, then OPEN(exec) → OPEN_OK → SESSION_DATA → EXIT — run entirely
+ * in-process. Both endpoints speak real wire bytes (length-prefixed CBOR
+ * frames through a FrameDecoder), so this is the same byte stream a Rust
+ * server would see; only the socket is replaced by two callbacks.
+ *
+ * The tiny server below enforces the spec's ordering: it refuses to open
+ * channels for clients that have not authenticated.
+ */
+
+import assert from 'node:assert/strict';
+import {
+  frameEncode, FrameDecoder,
+  MSG, msgName, CHANNEL_KIND, AUTH_METHOD,
+  hello, serverHello, challenge, auth, authOk, authFail,
+  open, openOk, openFail, sessionData, exit,
+  generateKeyPair, generateNonce, signChallenge, exportPublicKeyRaw,
+  importPublicKeyRaw, verifyChallenge, fingerprint,
+} from '@johnhenry/wsh';
+
+const transcript = [];
+const log = (who, msg) => transcript.push(`${who} ${msgName(msg.type)}`);
+
+// ── In-process "server" ───────────────────────────────────────────────
+
+function makeServer(sendToClient, authorizedFingerprints) {
+  const decoder = new FrameDecoder();
+  const state = { sessionId: 'sess-' + Math.random().toString(36).slice(2, 8), nonce: null, authed: false };
+  const send = (msg) => { log('  server →', msg); sendToClient(frameEncode(msg)); };
+
+  return async (chunk) => {
+    for (const msg of decoder.feed(chunk)) {
+      log('client →', msg);
+      switch (msg.type) {
+        case MSG.HELLO: {
+          state.nonce = generateNonce();
+          send(serverHello({ sessionId: state.sessionId, features: ['exec'] }));
+          send(challenge({ nonce: state.nonce }));
+          break;
+        }
+        case MSG.AUTH: {
+          const fp = await fingerprint(msg.public_key);
+          const key = await importPublicKeyRaw(msg.public_key);
+          const ok = authorizedFingerprints.has(fp) &&
+            await verifyChallenge(key, msg.signature, state.sessionId, state.nonce);
+          if (ok) {
+            state.authed = true;
+            send(authOk({ sessionId: state.sessionId, token: 'resume-token', ttl: 3600 }));
+          } else {
+            send(authFail({ reason: 'signature or key rejected' }));
+          }
+          break;
+        }
+        case MSG.OPEN: {
+          if (!state.authed) { send(openFail({ reason: 'not authenticated' })); break; }
+          assert.equal(msg.kind, CHANNEL_KIND.EXEC);
+          send(openOk({ channelId: 1, dataMode: 'virtual' }));
+          // "Run" the command and stream its output back.
+          const output = `hello from ${msg.command}\n`;
+          send(sessionData({ channelId: 1, data: new TextEncoder().encode(output) }));
+          send(exit({ channelId: 1, code: 0 }));
+          break;
+        }
+      }
+    }
+  };
+}
+
+// ── Wire the two endpoints together ───────────────────────────────────
+
+const clientDecoder = new FrameDecoder();
+const fromServer = [];
+let serverIngest;
+const clientSend = (msg) => serverIngest(frameEncode(msg));
+
+// Client identity, pre-authorized on the server (authorized_keys style).
+const { publicKey, privateKey } = await generateKeyPair();
+const clientFp = await fingerprint(await exportPublicKeyRaw(publicKey));
+serverIngest = makeServer(
+  (bytes) => fromServer.push(...clientDecoder.feed(bytes)),
+  new Set([clientFp]),
+);
+
+const nextFromServer = async (type) => {
+  while (fromServer.length === 0) await new Promise((r) => setTimeout(r, 1));
+  const msg = fromServer.shift();
+  assert.equal(msg.type, type, `expected ${msgName(type)}, got ${msgName(msg.type)}`);
+  return msg;
+};
+
+// ── The conversation ──────────────────────────────────────────────────
+
+// 1. Opening a channel before authenticating is refused.
+await clientSend(open({ kind: CHANNEL_KIND.EXEC, command: 'id' }));
+await nextFromServer(MSG.OPEN_FAIL);
+console.log('pre-auth OPEN refused, as the spec requires');
+
+// 2. Handshake.
+await clientSend(hello({ username: 'demo', authMethod: AUTH_METHOD.PUBKEY }));
+const srvHello = await nextFromServer(MSG.SERVER_HELLO);
+const chal = await nextFromServer(MSG.CHALLENGE);
+
+// 3. Challenge-response auth (same crypto as example 02).
+const { signature, publicKeyRaw } = await signChallenge(
+  privateKey, publicKey, srvHello.session_id, chal.nonce
+);
+await clientSend(auth({ method: AUTH_METHOD.PUBKEY, signature, publicKey: publicKeyRaw }));
+const ok = await nextFromServer(MSG.AUTH_OK);
+console.log(`authenticated: session ${ok.session_id}, resume token "${ok.token}"`);
+
+// 4. Exec a command over a channel.
+await clientSend(open({ kind: CHANNEL_KIND.EXEC, command: 'uname', cols: 80, rows: 24 }));
+await nextFromServer(MSG.OPEN_OK);
+const data = await nextFromServer(MSG.SESSION_DATA);
+const done = await nextFromServer(MSG.EXIT);
+
+console.log(`exec output: ${JSON.stringify(new TextDecoder().decode(data.data))}`);
+assert.equal(done.code, 0);
+
+console.log('\nmessage flow:');
+for (const line of transcript) console.log(`  ${line}`);
+console.log('ok: full handshake and exec channel completed over wire-format frames');

--- a/examples/04-recording-replays-with-original-timing.mjs
+++ b/examples/04-recording-replays-with-original-timing.mjs
@@ -1,0 +1,78 @@
+/**
+ * A recording replays with its original timing.
+ *
+ * wsh records PTY sessions as timestamped event streams and exports them in
+ * an asciicast-v2-compatible shape, so recordings interop with standard
+ * terminal players (asciinema et al.). This example records a short session,
+ * round-trips it through JSON export/import, and replays it — verifying that
+ * output comes back in order and that inter-event timing is preserved
+ * (sped up 20x so the example finishes quickly).
+ */
+
+import assert from 'node:assert/strict';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { SessionRecorder, SessionPlayer } from '@johnhenry/wsh';
+
+// ── Record a session ──────────────────────────────────────────────────
+
+const recorder = new SessionRecorder('demo-session', { width: 120, height: 30 });
+
+recorder.record('open', { command: '/bin/bash' });
+recorder.record('output', '$ ');
+await sleep(150);
+recorder.record('input', 'echo hello\r');
+recorder.record('output', 'echo hello\r\nhello\r\n$ ');
+await sleep(300);
+recorder.record('resize', { cols: 100, rows: 40 });
+await sleep(150);
+recorder.record('output', 'bye\r\n');
+recorder.record('exit', { code: 0 });
+
+console.log(`recorded ${recorder.length} events over ${recorder.duration}ms`);
+
+// ── Round-trip through the export format ──────────────────────────────
+
+const exported = recorder.toJSON();
+assert.equal(exported.version, 2);                    // asciicast v2
+assert.equal(exported.width, 100);                    // recorder tracked the mid-session resize
+assert.equal(exported.height, 40);
+assert.ok(exported.events.every((e) => Array.isArray(e) && e.length === 3));
+console.log(`exported asciicast v2: ${exported.events.length} [time, type, data] events`);
+
+const json = JSON.stringify(exported);                // what you'd write to disk
+const reimported = SessionRecorder.fromJSON(json);
+assert.equal(reimported.length, recorder.length);
+assert.equal(reimported.entries.at(-1).type, 'exit');
+console.log('re-imported from JSON string: event count and types intact');
+
+// ── Replay ────────────────────────────────────────────────────────────
+
+const player = new SessionPlayer(reimported); // accepts a recorder or plain JSON
+console.log(`player metadata: ${player.metadata.width}x${player.metadata.height}, ` +
+  `${player.metadata.duration}ms, ${player.metadata.eventCount} events`);
+
+const chunks = [];
+const timestamps = [];
+const t0 = performance.now();
+
+await new Promise((resolve) => {
+  player.play(
+    (data) => { chunks.push(data); timestamps.push(performance.now() - t0); },
+    {
+      speed: 20, // 20x: ~600ms of session replays in ~30ms
+      onEvent: (type) => { if (type === 'exit') resolve(); },
+    }
+  );
+});
+
+// Output content and order survived the round trip.
+assert.equal(chunks.join(''), '$ echo hello\r\nhello\r\n$ bye\r\n');
+console.log(`replayed terminal output: ${JSON.stringify(chunks.join(''))}`);
+
+// Timing survived: the last output was recorded ~600ms in, so at 20x it must
+// arrive later than the first output but within a few dozen ms.
+const spread = timestamps.at(-1) - timestamps[0];
+assert.ok(spread > 5, `expected timed playback, got ${spread.toFixed(1)}ms spread`);
+console.log(`inter-event timing preserved at 20x speed (${spread.toFixed(1)}ms spread on replay)`);
+
+console.log('ok: record → export → import → replay round trip complete');

--- a/examples/05-remote-mcp-tools-called-through-bridge.mjs
+++ b/examples/05-remote-mcp-tools-called-through-bridge.mjs
@@ -1,0 +1,89 @@
+/**
+ * Remote MCP tools are discovered and called through the bridge.
+ *
+ * WshMcpBridge lets a wsh client use MCP tools hosted on the remote server:
+ * MCP_DISCOVER/MCP_TOOLS to learn what exists, MCP_CALL/MCP_RESULT to invoke
+ * (spec/wsh-v1.md, message codes 0x40-0x43). The bridge only needs an object
+ * with `sendControl` + `addControlListener`/`removeControlListener`, so this
+ * example runs fully headless against an in-process server that answers on
+ * the control channel — no network, no real MCP host.
+ */
+
+import assert from 'node:assert/strict';
+import { WshMcpBridge, MSG, mcpTools, mcpResult } from '@johnhenry/wsh';
+
+// ── An in-process control channel with an MCP-capable "server" ────────
+
+const serverTools = {
+  read_file: {
+    description: 'Read a file from the remote host',
+    parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+    invoke: ({ path }) => ({ success: true, output: `contents of ${path}` }),
+  },
+  run_command: {
+    description: 'Run a shell command on the remote host',
+    parameters: { type: 'object', properties: { command: { type: 'string' } }, required: ['command'] },
+    invoke: ({ command }) => ({ success: true, output: { stdout: `ran: ${command}`, code: 0 } }),
+  },
+};
+
+const client = {
+  listeners: new Set(),
+  addControlListener(fn) { this.listeners.add(fn); },
+  removeControlListener(fn) { this.listeners.delete(fn); },
+  deliver(msg) { for (const fn of [...this.listeners]) fn(msg); },
+
+  // "Send to server": the server reacts and replies on the control channel.
+  // Replies arrive on a fresh task, as they would from a real transport.
+  async sendControl(msg) {
+    setTimeout(() => {
+      if (msg.type === MSG.MCP_DISCOVER) {
+        this.deliver(mcpTools({
+          tools: Object.entries(serverTools).map(([name, t]) => ({
+            name, description: t.description, parameters: t.parameters,
+          })),
+        }));
+      } else if (msg.type === MSG.MCP_CALL) {
+        this.deliver(mcpResult({ result: serverTools[msg.tool].invoke(msg.arguments) }));
+      }
+    }, 0);
+  },
+};
+
+// ── Discover ──────────────────────────────────────────────────────────
+
+const bridge = new WshMcpBridge(client);
+const tools = await bridge.discover();
+
+console.log(`discovered ${tools.length} remote tools:`);
+for (const t of tools) console.log(`  - ${t.name}: ${t.description}`);
+assert.equal(bridge.toolCount, 2);
+assert.ok(bridge.hasTool('read_file'));
+
+// Tool specs come back in a shape ready to register with an agent framework.
+const specs = bridge.getToolSpecs();
+assert.deepEqual(Object.keys(specs[0]), ['name', 'description', 'parameters']);
+
+// ── Call ──────────────────────────────────────────────────────────────
+
+const fileResult = await bridge.call('read_file', { path: '/etc/hostname' });
+assert.equal(fileResult.success, true);
+console.log(`read_file → ${JSON.stringify(fileResult.output)}`);
+
+const cmdResult = await bridge.call('run_command', { command: 'uptime' });
+assert.equal(cmdResult.output.code, 0);
+console.log(`run_command → ${JSON.stringify(cmdResult.output)}`);
+
+// ── Guardrail: unknown tools are rejected client-side after discovery ─
+
+await assert.rejects(
+  () => bridge.call('format_disk', {}),
+  /Unknown tool "format_disk"/,
+);
+console.log('call to undiscovered tool rejected before touching the wire');
+
+// The bridge stopped listening once each request settled.
+assert.equal(client.listeners.size, 0);
+console.log('no control listeners leaked after requests settled');
+
+console.log('ok: remote MCP tools discovered and called headlessly through the bridge');

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# wsh examples
+
+Small, self-contained, runnable demonstrations of wsh behavior. Every example runs headless under plain Node (>= 24, for WebCrypto Ed25519) with no network, no server, and no dependencies — protocol peers are simulated in-process, exchanging the same wire bytes a real transport would carry.
+
+Run one with `npm run example:01` (etc.), or all of them with `npm run examples`.
+
+| Example | Demonstrates |
+|---|---|
+| [`01-frames-survive-fragmented-transport.mjs`](./01-frames-survive-fragmented-transport.mjs) | Length-prefixed CBOR frames reassemble intact no matter how the byte stream is fragmented in transit. |
+| [`02-tampered-challenge-fails-authentication.mjs`](./02-tampered-challenge-fails-authentication.mjs) | Ed25519 challenge-response: the transcript binds signatures to session + nonce, so replays, forged nonces, and impostor keys are all rejected. |
+| [`03-handshake-to-exec-over-in-process-pipe.mjs`](./03-handshake-to-exec-over-in-process-pipe.mjs) | A full HELLO → CHALLENGE → AUTH → OPEN(exec) → SESSION_DATA → EXIT conversation in wire format, with pre-auth channel opens refused. |
+| [`04-recording-replays-with-original-timing.mjs`](./04-recording-replays-with-original-timing.mjs) | Session recording round-trips through asciicast-v2-compatible JSON and replays with inter-event timing preserved. |
+| [`05-remote-mcp-tools-called-through-bridge.mjs`](./05-remote-mcp-tools-called-through-bridge.mjs) | MCP tools on a remote host are discovered and invoked over the control channel, with undiscovered tools rejected client-side. |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,13 @@
     "README.md"
   ],
   "scripts": {
-    "test": "node --test test/*.test.mjs"
+    "test": "node --test test/*.test.mjs",
+    "examples": "for f in examples/0*.mjs; do echo \"== $f\" && node \"$f\" || exit 1; done",
+    "example:01": "node examples/01-frames-survive-fragmented-transport.mjs",
+    "example:02": "node examples/02-tampered-challenge-fails-authentication.mjs",
+    "example:03": "node examples/03-handshake-to-exec-over-in-process-pipe.mjs",
+    "example:04": "node examples/04-recording-replays-with-original-timing.mjs",
+    "example:05": "node examples/05-remote-mcp-tools-called-through-bridge.mjs"
   },
   "keywords": [
     "wsh",


### PR DESCRIPTION
Adds an `examples/` directory of five self-contained, headless examples plus an examples smoke step in CI.

## Examples
| File | Demonstrates |
|---|---|
| `01-frames-survive-fragmented-transport.mjs` | Length-prefixed CBOR frames reassemble intact under 1-byte drips and mid-payload splits |
| `02-tampered-challenge-fails-authentication.mjs` | Ed25519 transcript binding: replays across sessions, forged nonces, and impostor keys all rejected |
| `03-handshake-to-exec-over-in-process-pipe.mjs` | Full HELLO → CHALLENGE → AUTH → OPEN(exec) → SESSION_DATA → EXIT in wire format; pre-auth OPEN refused |
| `04-recording-replays-with-original-timing.mjs` | Recording round-trips through asciicast-v2 JSON and replays with inter-event timing preserved |
| `05-remote-mcp-tools-called-through-bridge.mjs` | MCP tool discovery + invocation over the control channel; undiscovered tools rejected client-side |

## Runtime
Plain Node >= 24 (WebCrypto Ed25519). No network, no server, no dependencies — peers are simulated in-process exchanging real wire bytes.

## Wiring
- `example:01`..`example:05` npm scripts + `examples` loop
- `examples/README.md` one-line index
- CI: `npm run examples` smoke step after `npm test`

## Gates
- `npm test`: 278/278 pass
- `npm run examples`: all five green