### PR TITLE
docs: link the docs-site section from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # wsh-upon-star
 
+Full documentation: [opensource.johnhenry.me/wsh](https://opensource.johnhenry.me/wsh/)
+
 > Previously published as `wsh-upon-star` (last release: 0.1.1, now deprecated).
 > Renamed to `@johnhenry/wsh` and restarted at 0.0.0 on import into the
 > @johnhenry family — a new name and era, not a maturity signal.


### PR DESCRIPTION
Cross-pollination pass (W-X) of the @johnhenry docs overhaul: every repo README links its section on opensource.johnhenry.me, matching the family convention (spintax, temporals, semantic-chunker, math, math-plus, optical-artifact-transport already do). One line, no other changes.