### PR TITLE
fix: audit findings — random session-id fallback, frame-size cap, spec drift

### DIFF
--- a/spec/codegen.mjs
+++ b/spec/codegen.mjs
@@ -1008,7 +1008,11 @@ function emitMarkdown(schema) {
   out.push('### WebSocket');
   out.push('');
   out.push(`- **Framing**: \`${schema.transport.websocket.framing}\``);
-  out.push(`- **WS_DATA type**: \`0x${schema.transport.websocket.ws_data_type.toString(16).padStart(2, '0')}\``);
+  for (const [name, code] of Object.entries(schema.transport.websocket.frame_types)) {
+    out.push(`- **${name} frame type**: \`0x${code.toString(16).padStart(2, '0')}\``);
+  }
+  out.push('');
+  out.push(schema.transport.websocket.note);
   out.push('');
 
   return out.join('\n');

--- a/spec/wsh-v1.md
+++ b/spec/wsh-v1.md
@@ -1325,5 +1325,10 @@ QUIC streams as channels. 1 bidi = control. Per channel: 1 bidi + optional uni.
 
 ### WebSocket
 
-- **Framing**: `[1B msg_type][4B stream_id][payload]`
-- **WS_DATA type**: `0x60`
+- **Framing**: `[1B frame_type][4B stream_id][payload]`
+- **control frame type**: `0x01`
+- **data frame type**: `0x02`
+- **open_stream frame type**: `0x03`
+- **close_stream frame type**: `0x04`
+
+Stream 0 carries length-prefixed CBOR control messages (frameEncode/FrameDecoder); other stream IDs carry raw data bytes with no extra framing. MSG.WS_DATA (0x60, defined under messages.framing.WsData in this spec) is an unrelated JS-only CBOR-opcode marker and is never sent as this frame_type byte -- see src/transport-ws.mjs for the reference implementation.

--- a/spec/wsh-v1.yaml
+++ b/spec/wsh-v1.yaml
@@ -1648,5 +1648,10 @@ transport:
   webtransport:
     description: "QUIC streams as channels. 1 bidi = control. Per channel: 1 bidi + optional uni."
   websocket:
-    framing: "[1B msg_type][4B stream_id][payload]"
-    ws_data_type: 0x60
+    framing: "[1B frame_type][4B stream_id][payload]"
+    frame_types:
+      control: 0x01
+      data: 0x02
+      open_stream: 0x03
+      close_stream: 0x04
+    note: "Stream 0 carries length-prefixed CBOR control messages (frameEncode/FrameDecoder); other stream IDs carry raw data bytes with no extra framing. MSG.WS_DATA (0x60, defined under messages.framing.WsData in this spec) is an unrelated JS-only CBOR-opcode marker and is never sent as this frame_type byte -- see src/transport-ws.mjs for the reference implementation."

--- a/src/cbor.mjs
+++ b/src/cbor.mjs
@@ -331,15 +331,56 @@ export function frameEncode(value) {
 }
 
 /**
+ * Default cap on a single frame's claimed payload length (16 MiB).
+ *
+ * This channel only ever carries CBOR control-message metadata (session
+ * lists, MCP tool results, recording-export/command-journal entries,
+ * etc.) — bulk data such as file transfers and PTY output travel over
+ * separate raw data streams with their own small chunking, not through
+ * this decoder. 16 MiB is generous headroom for legitimate control
+ * payloads while still bounding memory far below the 4 GiB a hostile or
+ * buggy peer could otherwise claim via the 32-bit length prefix.
+ */
+export const DEFAULT_MAX_FRAME_SIZE = 16 * 1024 * 1024;
+
+/**
+ * Thrown by {@link FrameDecoder#feed} when a frame's claimed length
+ * exceeds the decoder's configured maximum.
+ */
+export class FrameSizeError extends Error {
+  constructor(len, maxFrameSize) {
+    super(`Frame claims length ${len}, which exceeds the maximum of ${maxFrameSize} bytes`);
+    this.name = 'FrameSizeError';
+    this.len = len;
+    this.maxFrameSize = maxFrameSize;
+  }
+}
+
+/**
  * Streaming frame decoder. Feed it chunks and it yields complete messages.
  */
 export class FrameDecoder {
   #buffer = new Uint8Array(0);
+  #maxFrameSize;
+
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.maxFrameSize] - Maximum allowed claimed frame
+   *   length, in bytes. Frames claiming more than this are rejected as
+   *   soon as their length prefix is parsed, before any payload bytes
+   *   are buffered. Defaults to {@link DEFAULT_MAX_FRAME_SIZE}.
+   */
+  constructor({ maxFrameSize = DEFAULT_MAX_FRAME_SIZE } = {}) {
+    this.#maxFrameSize = maxFrameSize;
+  }
 
   /**
    * Feed bytes and return decoded messages.
    * @param {Uint8Array} chunk
    * @returns {Array} decoded JS values
+   * @throws {FrameSizeError} if a frame's claimed length exceeds the
+   *   configured maximum. The decoder's buffer is cleared before
+   *   throwing; callers should treat this as fatal for the connection.
    */
   feed(chunk) {
     this.#buffer = appendBuffer(this.#buffer, chunk);
@@ -347,6 +388,12 @@ export class FrameDecoder {
     while (this.#buffer.length >= 4) {
       const view = new DataView(this.#buffer.buffer, this.#buffer.byteOffset, 4);
       const len = view.getUint32(0);
+      if (len > this.#maxFrameSize) {
+        // Reject before accumulating toward the (possibly huge) claimed
+        // length — do not wait for the payload to arrive.
+        this.#buffer = new Uint8Array(0);
+        throw new FrameSizeError(len, this.#maxFrameSize);
+      }
       if (this.#buffer.length < 4 + len) break;
       const payload = this.#buffer.slice(4, 4 + len);
       this.#buffer = this.#buffer.slice(4 + len);

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -388,8 +388,11 @@ export class WshClient {
         }
 
         // We need a session ID for the transcript. Use the nonce-derived ID
-        // or a placeholder if the server hasn't provided one.
-        tempSessionId = tempSessionId || 'pending';
+        // or a fresh random placeholder if the server hasn't provided one.
+        // (A fixed literal here would make the transcript's session-id
+        // component identical across every connection taking this path,
+        // leaving only the nonce to bind the signature to this connection.)
+        tempSessionId = tempSessionId || crypto.randomUUID();
 
         const { signature, publicKeyRaw } = await signChallenge(
           keyPair.privateKey,
@@ -1445,7 +1448,9 @@ export class WshClient {
       } else if (firstResponse.type === MSG.CHALLENGE) {
         if (!keyPair) throw new Error('Server sent CHALLENGE but no key pair provided');
 
-        tempSessionId = tempSessionId || 'pending';
+        // See connect()'s CHALLENGE branch for why this must be random
+        // rather than a fixed literal.
+        tempSessionId = tempSessionId || crypto.randomUUID();
         const { signature, publicKeyRaw } = await signChallenge(
           keyPair.privateKey, keyPair.publicKey, tempSessionId, firstResponse.nonce
         );

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,11 +28,34 @@ export function cborDecode(data: Uint8Array): unknown;
 export function frameEncode(value: unknown): Uint8Array;
 
 /**
+ * Default cap on a single frame's claimed payload length (16 MiB).
+ */
+export const DEFAULT_MAX_FRAME_SIZE: number;
+
+/**
+ * Thrown by FrameDecoder#feed when a frame's claimed length exceeds the
+ * decoder's configured maximum.
+ */
+export class FrameSizeError extends Error {
+  constructor(len: number, maxFrameSize: number);
+  readonly len: number;
+  readonly maxFrameSize: number;
+}
+
+/**
  * Streaming frame decoder. Feed it chunks and it yields complete messages.
  */
 export class FrameDecoder {
   /**
+   * @param opts.maxFrameSize Maximum allowed claimed frame length in bytes.
+   *   Defaults to DEFAULT_MAX_FRAME_SIZE.
+   */
+  constructor(opts?: { maxFrameSize?: number });
+
+  /**
    * Feed bytes and return decoded messages.
+   * @throws {FrameSizeError} if a frame's claimed length exceeds the
+   *   configured maximum.
    */
   feed(chunk: Uint8Array): unknown[];
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -6,7 +6,7 @@
  */
 
 // CBOR codec + framing
-export { cborEncode, cborDecode, frameEncode, FrameDecoder } from './cbor.mjs';
+export { cborEncode, cborDecode, frameEncode, FrameDecoder, FrameSizeError, DEFAULT_MAX_FRAME_SIZE } from './cbor.mjs';
 
 // Protocol messages
 export {

--- a/src/transport-ws.mjs
+++ b/src/transport-ws.mjs
@@ -15,10 +15,18 @@
  * Data streams carry raw bytes with no additional framing.
  */
 
-import { frameEncode, FrameDecoder } from './cbor.mjs';
+import { frameEncode, FrameDecoder, FrameSizeError } from './cbor.mjs';
 import { WshTransport } from './transport.mjs';
 
 // ── Frame type constants ─────────────────────────────────────────────
+//
+// NOTE: these are unrelated to MSG.WS_DATA (0x60) in messages.gen.mjs.
+// WS_DATA is a JS-only, CBOR-layer bookkeeping marker (it shares its
+// opcode with MSG.DETACH and is explicitly excluded from the Rust
+// message enum by spec/codegen.mjs) — it is never sent as the outer
+// envelope's frame-type byte below. See spec/wsh-v1.yaml's
+// `transport.websocket` section for the authoritative outer-envelope
+// framing docs.
 
 const FRAME_CONTROL      = 0x01;
 const FRAME_DATA         = 0x02;
@@ -329,7 +337,18 @@ export class WebSocketTransport extends WshTransport {
    * @param {Uint8Array} payload
    */
   #handleControlFrame(payload) {
-    const messages = this.#decoder.feed(payload);
+    let messages;
+    try {
+      messages = this.#decoder.feed(payload);
+    } catch (err) {
+      this._emitError(err);
+      if (err instanceof FrameSizeError) {
+        // Oversized claimed frame length — treat as a hostile or badly
+        // broken peer and tear down the connection rather than continue.
+        this.close().catch(() => {});
+      }
+      return;
+    }
     for (const msg of messages) {
       this._emitControl(msg);
     }

--- a/src/transport.mjs
+++ b/src/transport.mjs
@@ -5,7 +5,7 @@
  * Data streams carry raw bytes with no framing overhead.
  */
 
-import { frameEncode, FrameDecoder, cborEncode } from './cbor.mjs';
+import { frameEncode, FrameDecoder, cborEncode, FrameSizeError } from './cbor.mjs';
 
 // ── Transport states ─────────────────────────────────────────────────
 
@@ -286,6 +286,11 @@ export class WebTransportTransport extends WshTransport {
     } catch (err) {
       if (!this.#abort.signal.aborted) {
         this._emitError(new Error(`Control stream read error: ${err.message}`));
+        if (err instanceof FrameSizeError) {
+          // Oversized claimed frame length — treat as a hostile or badly
+          // broken peer and tear down the connection rather than continue.
+          this.close().catch(() => {});
+        }
       }
     } finally {
       reader.releaseLock();

--- a/test/cbor.test.mjs
+++ b/test/cbor.test.mjs
@@ -1,6 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { cborEncode, cborDecode, frameEncode, FrameDecoder } from '../src/cbor.mjs';
+import {
+  cborEncode, cborDecode, frameEncode, FrameDecoder,
+  FrameSizeError, DEFAULT_MAX_FRAME_SIZE,
+} from '../src/cbor.mjs';
 
 describe('CBOR codec', () => {
   it('round-trips integers', () => {
@@ -125,6 +128,52 @@ describe('FrameDecoder', () => {
     const part2 = decoder.feed(frame.subarray(mid));
     assert.equal(part2.length, 1);
     assert.deepEqual(part2[0], msg);
+  });
+
+  // Regression test for: FrameDecoder had no maximum frame-size bound,
+  // allowing a peer to claim a length near UINT32_MAX and force the
+  // decoder to buffer unboundedly while waiting for the (possibly
+  // never-arriving) payload — a client-side memory-exhaustion DoS.
+  it('rejects a frame claiming a length near UINT32_MAX instead of buffering unboundedly', () => {
+    const decoder = new FrameDecoder();
+    const header = new Uint8Array(4);
+    new DataView(header.buffer).setUint32(0, 0xfffffffe); // ~4 GiB claimed length
+
+    assert.throws(() => decoder.feed(header), FrameSizeError);
+
+    // The bogus length must not be retained as "waiting for more bytes" —
+    // the decoder should not be sitting on a multi-gigabyte target.
+    assert.equal(decoder.pending, 0);
+  });
+
+  it('rejects an oversized frame before the payload has fully arrived', () => {
+    const decoder = new FrameDecoder({ maxFrameSize: 16 });
+    const msg = { data: 'this payload is well over sixteen bytes long' };
+    const frame = frameEncode(msg);
+    assert.ok(frame.length > 4 + 16);
+
+    // Feed only the 4-byte length prefix (which already claims more than
+    // the configured max) — decoding must fail immediately, without
+    // requiring the rest of the oversized payload to show up.
+    assert.throws(() => decoder.feed(frame.subarray(0, 4)), FrameSizeError);
+  });
+
+  it('respects a configurable maxFrameSize', () => {
+    const decoder = new FrameDecoder({ maxFrameSize: 8 });
+    const msg = { a: 'this is definitely more than eight bytes of CBOR' };
+    const frame = frameEncode(msg);
+    assert.throws(() => decoder.feed(frame), FrameSizeError);
+  });
+
+  it('still accepts frames within the default max frame size', () => {
+    const decoder = new FrameDecoder();
+    const msg = { data: 'x'.repeat(1024) };
+    const frame = frameEncode(msg);
+    assert.ok(frame.length < DEFAULT_MAX_FRAME_SIZE);
+
+    const messages = decoder.feed(frame);
+    assert.equal(messages.length, 1);
+    assert.deepEqual(messages[0], msg);
   });
 });
 

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { WshTransport } from '../src/transport.mjs';
+import { MSG } from '../src/messages.gen.mjs';
+
+// Note: Web Crypto API (crypto.subtle) with Ed25519 requires Node 20+ or a browser.
+// These tests will skip gracefully if Ed25519 is not available.
+
+let auth;
+let clientMod;
+try {
+  auth = await import('../src/auth.mjs');
+  clientMod = await import('../src/client.mjs');
+} catch {
+  // Module import may fail in environments without Web Crypto Ed25519
+}
+
+const hasEd25519 = auth && typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined';
+
+/**
+ * A minimal in-memory transport that skips SERVER_HELLO and replies to
+ * HELLO with CHALLENGE directly, then replies to AUTH with AUTH_OK that
+ * does *not* include a session_id — so the client's final sessionId is
+ * exactly the fallback `tempSessionId` computed for the CHALLENGE branch.
+ * This isolates the value under test (regression for the 'pending'
+ * hardcoded session-id finding).
+ */
+class ChallengeFirstMockTransport extends WshTransport {
+  sentMessages = [];
+
+  async _doConnect() {
+    // no-op: immediately "connected"
+  }
+
+  async _doClose() {
+    // no-op
+  }
+
+  async _doSendControl(msg) {
+    this.sentMessages.push(msg);
+    // Reply on a macrotask (not queueMicrotask): the caller registers its
+    // response waiter via a microtask continuation right after this call
+    // resolves, so replying via another microtask can race ahead of that
+    // registration and get silently dropped.
+    if (msg.type === MSG.HELLO) {
+      setTimeout(() => {
+        this._emitControl({ type: MSG.CHALLENGE, nonce: new Uint8Array(32).fill(7) });
+      }, 0);
+    } else if (msg.type === MSG.AUTH) {
+      setTimeout(() => {
+        this._emitControl({ type: MSG.AUTH_OK });
+      }, 0);
+    }
+  }
+
+  async _doOpenStream() {
+    throw new Error('not needed for this test');
+  }
+}
+
+describe('WshClient auth handshake', { skip: !hasEd25519 && 'Ed25519 not available in this runtime' }, () => {
+  // Regression test for: the client used the literal string 'pending' as
+  // the transcript session-id placeholder whenever a server skipped
+  // SERVER_HELLO and sent CHALLENGE directly, making the session-id
+  // component of the auth transcript identical across every connection
+  // taking that path.
+
+  it('connect(): CHALLENGE-first handshake uses a fresh per-connection session id, not "pending"', async () => {
+    const keyPair = await auth.generateKeyPair(true);
+
+    async function runOnce() {
+      const client = new clientMod.WshClient({
+        transportFactories: { ws: () => new ChallengeFirstMockTransport() },
+      });
+      return client.connect('ws://test.invalid', {
+        username: 'alice',
+        keyPair,
+        transport: 'ws',
+      });
+    }
+
+    const id1 = await runOnce();
+    const id2 = await runOnce();
+
+    assert.notEqual(id1, 'pending');
+    assert.notEqual(id2, 'pending');
+    assert.notEqual(id1, id2, 'two separate connections must not reuse the same fallback session id');
+  });
+
+  it('connectWithTransport()/#performAuth(): CHALLENGE-first handshake uses a fresh per-connection session id, not "pending"', async () => {
+    const keyPair = await auth.generateKeyPair(true);
+
+    async function runOnce() {
+      const client = new clientMod.WshClient();
+      const transport = new ChallengeFirstMockTransport();
+      return client.connectWithTransport(transport, 'ws://test.invalid', {
+        username: 'bob',
+        keyPair,
+      });
+    }
+
+    const id1 = await runOnce();
+    const id2 = await runOnce();
+
+    assert.notEqual(id1, 'pending');
+    assert.notEqual(id2, 'pending');
+    assert.notEqual(id1, id2, 'two separate connections must not reuse the same fallback session id');
+  });
+});


### PR DESCRIPTION
## Summary

Closes 3 MEDIUM-severity findings from a bug-hunt audit:

- Fixes #5 — the CHALLENGE-without-SERVER_HELLO handshake path built the
  auth transcript with the hardcoded literal `'pending'` as the
  session-id placeholder (`src/client.mjs:392` and `:1448`), making that
  transcript component identical across every connection taking this
  path. Now uses `crypto.randomUUID()` so each connection gets a unique
  value.
- Fixes #6 — `FrameDecoder.feed()` (`src/cbor.mjs`) accepted any 32-bit
  claimed frame length and buffered unboundedly waiting for it to
  arrive, allowing a peer to claim a length near `UINT32_MAX` and force
  unbounded client-side memory growth. Added a configurable
  `maxFrameSize` (default 16 MiB — this channel only ever carries CBOR
  control metadata; file/PTY bytes go over separate raw data streams
  with their own 64 KB chunking), checked immediately after the length
  prefix is parsed and *before* any payload buffering. Both transports
  (`transport.mjs`, `transport-ws.mjs`) now close the connection when a
  `FrameSizeError` is thrown.
- Fixes #4 — `spec/wsh-v1.yaml`'s outer WebSocket envelope section
  documented `ws_data_type: 0x60`, but `src/transport-ws.mjs` has always
  used `0x01`/`0x02`/`0x03`/`0x04` for CONTROL/DATA/OPEN_STREAM/
  CLOSE_STREAM. Investigation (git history, tests, `spec/codegen.mjs`)
  found `0x60` is `MSG.WS_DATA`, an unrelated JS-only CBOR-opcode marker
  (aliased with `MSG.DETACH`) that `codegen.mjs` explicitly excludes
  from the Rust message enum — never a real outer-envelope value. The
  `0x01`-`0x04` path is what the test suite exercises, so this is a
  **documentation-only** fix: the spec (plus its generated `wsh-v1.md`
  and the `codegen.mjs` markdown emitter) now documents the real frame
  types, and a clarifying comment was added near
  `src/transport-ws.mjs:23`. No runtime behavior changed for this one.

Each of the first two fixes ships with a regression test
(`test/client.test.mjs`, `test/cbor.test.mjs`).

## Test plan

- [x] `npm test` — 278 baseline tests → 284 tests (278 + 6 new), all
      passing, 0 failures
- [x] `npm run examples` — all 5 example smoke scripts still pass
      unmodified
- [x] Manually traced the minimal YAML parser in `spec/codegen.mjs`
      against the edited `spec/wsh-v1.yaml` transport section to confirm
      it still parses correctly and the markdown emitter output matches
      what was hand-written into `spec/wsh-v1.md` (the emitter's actual
      write paths are stale from a prior monorepo layout and can't be
      run directly in this repo without writing outside it, pre-existing
      and out of scope here)