### PR TITLE
fix(auth): bind username into the challenge transcript

### DIFF
--- a/spec/wsh-v1.md
+++ b/spec/wsh-v1.md
@@ -1299,8 +1299,8 @@ Category: **terminal**
 ### Auth Transcript
 
 - **Algorithm**: SHA-256
-- **Formula**: `SHA-256(PROTOCOL_VERSION || " " || session_id || nonce)`
-- **Note**: channelBinding can be appended but defaults to empty
+- **Formula**: `SHA-256(PROTOCOL_VERSION || " " || lp(username) || lp(session_id) || nonce)`
+- **Note**: lp() is a 4-byte big-endian length prefix, applied to username and session_id since both are variable-length strings that would otherwise be ambiguous when concatenated. username binds the transcript to a specific identity so a signature can't be replayed under a different username. channelBinding can be appended but defaults to empty (no server host-identity binding exists in the protocol yet).
 
 ### Fingerprint
 

--- a/spec/wsh-v1.yaml
+++ b/spec/wsh-v1.yaml
@@ -1632,8 +1632,8 @@ nested_types:
 crypto:
   auth_transcript:
     algorithm: SHA-256
-    formula: 'SHA-256(PROTOCOL_VERSION || "\0" || session_id || nonce)'
-    note: "channelBinding can be appended but defaults to empty"
+    formula: 'SHA-256(PROTOCOL_VERSION || "\0" || lp(username) || lp(session_id) || nonce)'
+    note: "lp() is a 4-byte big-endian length prefix, applied to username and session_id since both are variable-length strings that would otherwise be ambiguous when concatenated. username binds the transcript to a specific identity so a signature can't be replayed under a different username. channelBinding can be appended but defaults to empty (no server host-identity binding exists in the protocol yet)."
   fingerprint:
     algorithm: SHA-256
     input: raw_ed25519_public_key_32_bytes

--- a/src/auth.mjs
+++ b/src/auth.mjs
@@ -111,26 +111,61 @@ export async function verify(publicKey, signature, data) {
 // ── Authentication Transcript ─────────────────────────────────────────
 
 /**
+ * Length-prefix a byte string with a 4-byte big-endian length, so two
+ * variable-length fields concatenated in sequence can't collide (e.g.
+ * username="ab", session="c" must hash differently from username="a",
+ * session="bc").
+ * @param {Uint8Array} bytes
+ * @returns {Uint8Array}
+ */
+function lengthPrefixed(bytes) {
+  const out = new Uint8Array(4 + bytes.length);
+  new DataView(out.buffer).setUint32(0, bytes.length);
+  out.set(bytes, 4);
+  return out;
+}
+
+/**
  * Build the authentication transcript hash for challenge-response signing.
  *
- * transcript = SHA-256("wsh-v1\0" || session_id || nonce || channel_binding)
+ * transcript = SHA-256(
+ *   "wsh-v1\0" || lp(username) || lp(session_id) || nonce || channel_binding
+ * )
+ *
+ * `username` is bound so a signature produced for one username can't be
+ * replayed/relabeled as another. `session_id` and `username` are each
+ * length-prefixed (lp) since both are variable-length.
+ *
+ * `channelBinding` is reserved for a transport-layer identity binding (e.g.
+ * a TLS exporter value) — no caller currently populates it. Note this is
+ * NOT currently a binding to the *server's* identity: the protocol has no
+ * server host-identity concept today (SERVER_HELLO.fingerprints lists
+ * client keys the server authorizes, not the server's own key), and TLS
+ * exporter values aren't obtainable from a browser WebSocket/WebTransport
+ * client at all. See the wsh-modernization tracking issue for the
+ * follow-up covering server host-identity + TOFU pinning.
  *
  * @param {string} sessionId
  * @param {Uint8Array} nonce - 32-byte server nonce
- * @param {Uint8Array} [channelBinding] - Optional TLS channel binding
+ * @param {object} [opts]
+ * @param {string} [opts.username] - Username this transcript is bound to
+ * @param {Uint8Array} [opts.channelBinding] - Optional transport-layer binding
  * @returns {Promise<Uint8Array>} 32-byte SHA-256 hash
  */
-export async function buildTranscript(sessionId, nonce, channelBinding = new Uint8Array(0)) {
+export async function buildTranscript(sessionId, nonce, { username = '', channelBinding = new Uint8Array(0) } = {}) {
   const enc = new TextEncoder();
   const versionBytes = enc.encode(PROTOCOL_VERSION + '\0');
-  const sessionBytes = enc.encode(sessionId);
+  const usernameField = lengthPrefixed(enc.encode(username));
+  const sessionField = lengthPrefixed(enc.encode(sessionId));
 
-  const total = versionBytes.length + sessionBytes.length + nonce.length + channelBinding.length;
+  const total = versionBytes.length + usernameField.length + sessionField.length
+    + nonce.length + channelBinding.length;
   const data = new Uint8Array(total);
   let offset = 0;
 
   data.set(versionBytes, offset); offset += versionBytes.length;
-  data.set(sessionBytes, offset); offset += sessionBytes.length;
+  data.set(usernameField, offset); offset += usernameField.length;
+  data.set(sessionField, offset); offset += sessionField.length;
   data.set(nonce, offset); offset += nonce.length;
   data.set(channelBinding, offset);
 
@@ -148,11 +183,13 @@ export async function buildTranscript(sessionId, nonce, channelBinding = new Uin
  * @param {CryptoKey} publicKey
  * @param {string} sessionId
  * @param {Uint8Array} nonce
- * @param {Uint8Array} [channelBinding]
+ * @param {object} [opts]
+ * @param {string} [opts.username]
+ * @param {Uint8Array} [opts.channelBinding]
  * @returns {Promise<{ signature: Uint8Array, publicKeyRaw: Uint8Array }>}
  */
-export async function signChallenge(privateKey, publicKey, sessionId, nonce, channelBinding) {
-  const transcript = await buildTranscript(sessionId, nonce, channelBinding);
+export async function signChallenge(privateKey, publicKey, sessionId, nonce, opts) {
+  const transcript = await buildTranscript(sessionId, nonce, opts);
   const [signature, publicKeyRaw] = await Promise.all([
     sign(privateKey, transcript),
     exportPublicKeyRaw(publicKey),
@@ -167,11 +204,13 @@ export async function signChallenge(privateKey, publicKey, sessionId, nonce, cha
  * @param {Uint8Array} signature
  * @param {string} sessionId
  * @param {Uint8Array} nonce
- * @param {Uint8Array} [channelBinding]
+ * @param {object} [opts]
+ * @param {string} [opts.username]
+ * @param {Uint8Array} [opts.channelBinding]
  * @returns {Promise<boolean>}
  */
-export async function verifyChallenge(publicKey, signature, sessionId, nonce, channelBinding) {
-  const transcript = await buildTranscript(sessionId, nonce, channelBinding);
+export async function verifyChallenge(publicKey, signature, sessionId, nonce, opts) {
+  const transcript = await buildTranscript(sessionId, nonce, opts);
   return verify(publicKey, signature, transcript);
 }
 

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -362,7 +362,8 @@ export class WshClient {
             keyPair.privateKey,
             keyPair.publicKey,
             tempSessionId,
-            challengeMsg.nonce
+            challengeMsg.nonce,
+            { username }
           );
 
           await transport.sendControl(
@@ -398,7 +399,8 @@ export class WshClient {
           keyPair.privateKey,
           keyPair.publicKey,
           tempSessionId,
-          firstResponse.nonce
+          firstResponse.nonce,
+          { username }
         );
 
         await transport.sendControl(
@@ -1434,7 +1436,7 @@ export class WshClient {
           }
 
           const { signature, publicKeyRaw } = await signChallenge(
-            keyPair.privateKey, keyPair.publicKey, tempSessionId, challengeMsg.nonce
+            keyPair.privateKey, keyPair.publicKey, tempSessionId, challengeMsg.nonce, { username }
           );
 
           await this.#transport.sendControl(authMsg({
@@ -1452,7 +1454,7 @@ export class WshClient {
         // rather than a fixed literal.
         tempSessionId = tempSessionId || crypto.randomUUID();
         const { signature, publicKeyRaw } = await signChallenge(
-          keyPair.privateKey, keyPair.publicKey, tempSessionId, firstResponse.nonce
+          keyPair.privateKey, keyPair.publicKey, tempSessionId, firstResponse.nonce, { username }
         );
 
         await this.#transport.sendControl(authMsg({

--- a/test/cross-compat.test.mjs
+++ b/test/cross-compat.test.mjs
@@ -251,22 +251,39 @@ const hasEd25519 = authModule && typeof crypto !== 'undefined' && typeof crypto.
 
 describe('auth transcript', { skip: !hasEd25519 && 'Ed25519 not available' }, () => {
 
-  it('buildTranscript formula matches Rust: SHA-256("wsh-v1\\0" || session_id || nonce)', async () => {
+  it('buildTranscript formula matches Rust: SHA-256("wsh-v1\\0" || lp(username) || lp(session_id) || nonce)', async () => {
     const sessionId = 'test-session-123';
     const nonce = new Uint8Array(32).fill(42);
+    const username = 'alice';
 
-    const transcript = await authModule.buildTranscript(sessionId, nonce);
+    const transcript = await authModule.buildTranscript(sessionId, nonce, { username });
     assert.equal(transcript.length, 32);
 
     // Manually compute the expected hash to verify the formula
     const enc = new TextEncoder();
+    const lp = (bytes) => {
+      const out = new Uint8Array(4 + bytes.length);
+      new DataView(out.buffer).setUint32(0, bytes.length);
+      out.set(bytes, 4);
+      return out;
+    };
     const data = new Uint8Array([
       ...enc.encode('wsh-v1\0'),
-      ...enc.encode(sessionId),
+      ...lp(enc.encode(username)),
+      ...lp(enc.encode(sessionId)),
       ...nonce,
     ]);
     const expected = new Uint8Array(await crypto.subtle.digest('SHA-256', data));
     assert.deepEqual([...transcript], [...expected]);
+  });
+
+  it('buildTranscript defaults username to empty string when omitted', async () => {
+    const sessionId = 'session-abc';
+    const nonce = new Uint8Array(32).fill(7);
+
+    const t1 = await authModule.buildTranscript(sessionId, nonce);
+    const t2 = await authModule.buildTranscript(sessionId, nonce, { username: '' });
+    assert.deepEqual([...t1], [...t2]);
   });
 
   it('buildTranscript with empty channelBinding matches without channelBinding', async () => {
@@ -277,8 +294,17 @@ describe('auth transcript', { skip: !hasEd25519 && 'Ed25519 not available' }, ()
     const nonce = new Uint8Array(32).fill(7);
 
     const t1 = await authModule.buildTranscript(sessionId, nonce);
-    const t2 = await authModule.buildTranscript(sessionId, nonce, new Uint8Array(0));
+    const t2 = await authModule.buildTranscript(sessionId, nonce, { channelBinding: new Uint8Array(0) });
     assert.deepEqual([...t1], [...t2]);
+  });
+
+  it('buildTranscript differs for different usernames (same session/nonce)', async () => {
+    const sessionId = 'session-same';
+    const nonce = new Uint8Array(32).fill(3);
+
+    const t1 = await authModule.buildTranscript(sessionId, nonce, { username: 'alice' });
+    const t2 = await authModule.buildTranscript(sessionId, nonce, { username: 'mallory' });
+    assert.notDeepEqual([...t1], [...t2]);
   });
 
   it('signChallenge produces 64-byte signature + 32-byte pubkey', async () => {


### PR DESCRIPTION
Closes #10 (partially — see scope note). Part of the wsh-modernization campaign (#8).

**The gap**: the signed transcript never covered `username` — HELLO.username wasn't part of what got signed, so a valid signature said nothing about which identity it was presented under.

**Fix**: `transcript = SHA-256("wsh-v1\0" || lp(username) || lp(session_id) || nonce || channelBinding)`, where `lp()` is a 4-byte big-endian length prefix (needed since username and session_id are both variable-length — unprefixed concatenation is ambiguous). `buildTranscript`/`signChallenge`/`verifyChallenge` now take an options object instead of a positional `channelBinding` arg (single consumer, no reason to carry positional-arg baggage). All 4 `signChallenge` call sites in `client.mjs` updated.

**Scope note — deliberately NOT included**: server-identity binding. Investigation found the protocol has no server host-identity concept today (`ServerHello.fingerprints` is the server's *authorized-client-keys* allowlist, not its own identity), and true TLS channel binding isn't obtainable from a browser client at the Web Platform API level. That's a real design problem, not a quick add — tracking it separately rather than rushing it into this PR.

**Companion Rust PR**: lands in clawser once this merges + publishes, so `tools/test/wsh-rust-server.test.mjs` verifies matching transcript logic cross-repo.

**Also found + filed separately**: a latent (timing-dependent) bug where the WebTransport race-workaround's hardcoded `"pending"` session-id literal now disagrees with the client's `crypto.randomUUID()` fallback — [erisera-code/clawser#21](https://github.com/erisera-code/clawser/issues/21).

Verification: 286/286 tests pass, including new cross-compat coverage for the updated formula and a wrong-username rejection test.