### PR TITLE
Add EncryptedFrame AEAD sealing/opening (PR 1 of E2E rollout)

### DIFF
--- a/spec/wsh-v1.md
+++ b/spec/wsh-v1.md
@@ -1065,6 +1065,7 @@ Category: **e2e**
 
 | Field | Type | Required | Default |
 |-------|------|----------|---------|
+| `channel_id` | `u32` | yes | — |
 | `nonce` | `bytes` | yes | — |
 | `ciphertext` | `bytes` | yes | — |
 | `session_id` | `string` | yes | — |

--- a/spec/wsh-v1.yaml
+++ b/spec/wsh-v1.yaml
@@ -1292,28 +1292,32 @@ messages:
           type: string
           required: false
 
-  # ── E2E encryption (EXPERIMENTAL, incomplete) ────────────────────────
+  # ── E2E encryption (EXPERIMENTAL) ─────────────────────────────────────
   # Inner encryption layer intended for end-to-end confidentiality: after
-  # key exchange, session data would be wrapped in EncryptedFrame messages
-  # so the server cannot read session content. Currently incomplete on
-  # both sides of the wire: WshClient.initiateE2E() performs a real X25519
-  # ECDH exchange (optionally hybrid with ML-KEM-768, see below) and
-  # derives an AES-256-GCM key (src/client.mjs), but nothing constructs or
-  # consumes an EncryptedFrame with it -- the derived key is never
-  # actually used to seal/open anything. The Rust client has no
-  # KeyExchange/EncryptedFrame support at all; the Rust server only
-  # relays both message types opaquely between session participants
-  # (correct for true E2E, but doesn't imply either side actually
-  # encrypts). Do not rely on this for confidentiality today. Completing
-  # it (real AEAD sealing on both languages) is tracked as a follow-up,
-  # separate from the hybrid PQ handshake work this section now covers.
+  # key exchange, session data is wrapped in EncryptedFrame messages so
+  # the server cannot read session content. Status per side of the wire:
+  # WshClient.initiateE2E() performs a real X25519 ECDH exchange
+  # (optionally hybrid with ML-KEM-768, see below) and derives an
+  # AES-256-GCM key (src/client.mjs); as of this JS library's
+  # EncryptedFrame support (wsh #19), that key is now actually used to
+  # seal/open virtual-mode session data via WshSession.enableE2E()
+  # (src/session.mjs, src/e2e-frame.mjs) -- stream-mode sessions (raw
+  # byte streams, no message boundaries) aren't wired up yet. The Rust
+  # client (clawser's wsh-client crate) does have KeyExchange/
+  # initiate_e2e support, but does not yet construct or consume
+  # EncryptedFrame -- that AEAD sealing is tracked as a separate
+  # follow-up in that repo. The Rust server only relays both message
+  # types opaquely between session participants (correct for true E2E,
+  # but doesn't imply either side actually encrypts). Do not rely on
+  # this for confidentiality against a peer that hasn't actually called
+  # enableE2E()/opened an EncryptedFrame-sealing equivalent.
   e2e:
     KeyExchange:
       code: 0x8e
       description: >
         Key exchange for establishing a shared secret, X25519 or hybrid
-        X25519+ML-KEM-768. See the e2e section note above -- the derived
-        secret is not yet wired to any actual encryption.
+        X25519+ML-KEM-768. See the e2e section note above for which
+        peers currently wire the derived secret to actual encryption.
 
         Classical mode ("X25519"): both sides send only public_key
         (their ephemeral X25519 public key); the shared secret is
@@ -1359,18 +1363,26 @@ messages:
     EncryptedFrame:
       code: 0x8f
       description: >
-        An encrypted payload. Once KeyExchange's derived secret is
-        actually wired to real encryption (see the e2e section note
-        above -- not yet true today), session data would be sent inside
-        EncryptedFrame messages using AES-256-GCM AEAD, matching the
-        cipher WshClient.initiateE2E() already derives a key for
-        (src/client.mjs) -- picked over the ChaCha20-Poly1305 this field
-        previously described because it's natively supported by
-        SubtleCrypto in every shipping browser, matching this library's
-        zero-runtime-dependency, Web-Crypto-native design; ChaCha20-
-        Poly1305 has no native browser support and would require
-        bundling a JS implementation.
+        An encrypted payload carrying virtual-mode session data, once
+        KeyExchange's derived secret is wired to real encryption via
+        WshSession.enableE2E() (see the e2e section note above). Sent
+        using AES-256-GCM AEAD, matching the cipher
+        WshClient.initiateE2E() derives a key for (src/client.mjs) --
+        picked over the ChaCha20-Poly1305 this field previously
+        described because it's natively supported by SubtleCrypto in
+        every shipping browser, matching this library's zero-runtime-
+        dependency, Web-Crypto-native design; ChaCha20-Poly1305 has no
+        native browser support and would require bundling a JS
+        implementation. The nonce is 8 bytes of big-endian monotonic
+        send counter followed by a 4-byte fixed per-sender role tag
+        (see src/e2e-frame.mjs); session_id is bound as AEAD additional
+        authenticated data so a relay can't splice ciphertext across
+        sessions.
       fields:
+        channel_id:
+          type: u32
+          required: true
+          description: "Which channel (session) this frame belongs to -- same routing role as SessionData.channel_id."
         nonce:
           type: bytes
           required: true

--- a/src/e2e-frame.mjs
+++ b/src/e2e-frame.mjs
@@ -1,0 +1,177 @@
+/**
+ * EncryptedFrame sealing/opening for wsh's opt-in end-to-end encryption
+ * layer (see `client.mjs`'s `initiateE2E`, which derives the AES-256-GCM
+ * `CryptoKey` this module seals/opens with, and `spec/wsh-v1.yaml`'s
+ * `EncryptedFrame` message).
+ *
+ * This is PR 1 of a multi-PR E2E rollout: it implements the AEAD
+ * primitives and wires them into virtual-mode sessions only (see
+ * `session.mjs`'s `enableE2E`). Stream-mode sessions (raw WebTransport
+ * byte streams with no message boundaries) are explicitly out of scope
+ * here -- they need separate ad hoc chunk-framing design.
+ *
+ * ── Nonce construction ─────────────────────────────────────────────
+ * Nonces are the AES-GCM-mandated 96 bits (12 bytes), built as:
+ *
+ *   [ 8-byte big-endian monotonic counter ][ 4-byte sender-role tag ]
+ *
+ * The counter starts at 0 and increments by one for every frame a given
+ * sender seals (never reused, per `openFrame`'s strict expected-counter
+ * check below). The 4-byte role tag is fixed per sender for the
+ * lifetime of one E2E-enabled connection (see `session.mjs`'s
+ * `enableE2E({ role })`) and differs between the two peers of a
+ * session, so the two directions of one session structurally cannot
+ * produce a colliding nonce even under fully concurrent bidirectional
+ * traffic -- the 8-byte counter alone would collide if both sides ever
+ * reached the same count, but the two peers' tags never match, so the
+ * full 12-byte nonces never match either.
+ *
+ * ── AAD ────────────────────────────────────────────────────────────
+ * The frame's `session_id` (UTF-8 bytes) is bound as AES-GCM
+ * "additional authenticated data": it's authenticated but never
+ * encrypted, so ciphertext can't be spliced from one session onto
+ * another by a relay that only ever sees ciphertext (the server, for a
+ * genuinely E2E session) -- decryption fails if the session_id supplied
+ * to `openFrame` doesn't match the one the ciphertext was sealed under.
+ *
+ * ── Replay/reorder protection ─────────────────────────────────────
+ * `openFrame` requires the frame's nonce counter to be *exactly* the
+ * caller-supplied `expectedCounter` -- not merely "not yet seen" or
+ * "not too old". This is intentionally strict for v1: any replayed,
+ * duplicated, dropped, or reordered frame is rejected outright rather
+ * than tolerated or reordered-and-delivered. A later PR can relax this
+ * to a sliding window if wsh ever needs to tolerate out-of-order
+ * delivery for E2E frames; today's virtual-mode transport already
+ * delivers control messages in order, so strict-next-counter is not a
+ * practical limitation.
+ *
+ * ── Key lifetime ───────────────────────────────────────────────────
+ * The `key` passed to `sealFrame`/`openFrame` is connection-scoped, not
+ * session-scoped: a session that is detached and later Resumed/Attached
+ * on a new connection MUST run a fresh `initiateE2E()` and call
+ * `enableE2E()` again with the new key. Never persist or reuse a
+ * `sharedSecret` (or its counters) across a resume -- see
+ * `session.mjs`'s `enableE2E` doc comment.
+ */
+
+const NONCE_LENGTH = 12;
+const COUNTER_LENGTH = 8;
+const ROLE_TAG_LENGTH = 4;
+
+const textEncoder = new TextEncoder();
+
+/**
+ * Encode a non-negative integer counter as an 8-byte big-endian value.
+ * @param {number} counter
+ * @returns {Uint8Array}
+ */
+function encodeCounter(counter) {
+  if (!Number.isInteger(counter) || counter < 0) {
+    throw new Error(`e2e-frame: counter must be a non-negative integer, got ${counter}`);
+  }
+  const bytes = new Uint8Array(COUNTER_LENGTH);
+  const view = new DataView(bytes.buffer);
+  // DataView.setBigUint64 covers the full 64-bit range; counters here
+  // never realistically approach it, but there's no reason to cap early.
+  view.setBigUint64(0, BigInt(counter), false);
+  return bytes;
+}
+
+/**
+ * Build the 12-byte nonce for a given (counter, role tag) pair. Exported
+ * mainly for tests -- callers should go through `sealFrame`/`openFrame`.
+ *
+ * @param {number} counter
+ * @param {Uint8Array} roleTag - exactly 4 bytes
+ * @returns {Uint8Array}
+ */
+export function buildNonce(counter, roleTag) {
+  if (!(roleTag instanceof Uint8Array) || roleTag.length !== ROLE_TAG_LENGTH) {
+    throw new Error(`e2e-frame: roleTag must be a ${ROLE_TAG_LENGTH}-byte Uint8Array`);
+  }
+  const nonce = new Uint8Array(NONCE_LENGTH);
+  nonce.set(encodeCounter(counter), 0);
+  nonce.set(roleTag, COUNTER_LENGTH);
+  return nonce;
+}
+
+/**
+ * Seal a plaintext frame under an AES-256-GCM key.
+ *
+ * @param {CryptoKey} key - non-extractable AES-GCM CryptoKey (e.g. from `client.mjs`'s `initiateE2E`)
+ * @param {string} sessionId - bound as AAD
+ * @param {Uint8Array} roleTag - 4-byte sender role tag, distinct between the two peers of a session
+ * @param {number} counter - this sender's next monotonic send counter (0, 1, 2, ...)
+ * @param {Uint8Array} plaintext
+ * @returns {Promise<{nonce: Uint8Array, ciphertext: Uint8Array}>}
+ */
+export async function sealFrame(key, sessionId, roleTag, counter, plaintext) {
+  if (!key || typeof key !== 'object') {
+    throw new Error('e2e-frame: sealFrame requires a CryptoKey');
+  }
+  const nonce = buildNonce(counter, roleTag);
+  const aad = textEncoder.encode(sessionId);
+  const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: nonce, additionalData: aad },
+    key,
+    plaintext
+  ));
+  return { nonce, ciphertext };
+}
+
+/**
+ * Open (decrypt + authenticate) a sealed frame.
+ *
+ * Throws if:
+ *  - the AEAD authentication tag doesn't verify (tampered ciphertext,
+ *    wrong key, or `sessionId` mismatch since it's bound as AAD), or
+ *  - the frame's nonce counter isn't exactly `expectedCounter` (replay,
+ *    reorder, or drop -- see this module's doc comment).
+ *
+ * @param {CryptoKey} key
+ * @param {string} sessionId - must match what the frame was sealed with (bound as AAD)
+ * @param {number} expectedCounter - the exact next counter this peer expects from the sender
+ * @param {{nonce: Uint8Array, ciphertext: Uint8Array}} frame
+ * @returns {Promise<Uint8Array>} plaintext
+ */
+export async function openFrame(key, sessionId, expectedCounter, { nonce, ciphertext }) {
+  if (!key || typeof key !== 'object') {
+    throw new Error('e2e-frame: openFrame requires a CryptoKey');
+  }
+  if (!(nonce instanceof Uint8Array) || nonce.length !== NONCE_LENGTH) {
+    throw new Error(`e2e-frame: nonce must be a ${NONCE_LENGTH}-byte Uint8Array`);
+  }
+  const actualCounter = Number(new DataView(nonce.buffer, nonce.byteOffset, nonce.byteLength).getBigUint64(0, false));
+  if (actualCounter !== expectedCounter) {
+    throw new Error(
+      `e2e-frame: replay/reorder detected -- expected counter ${expectedCounter}, got ${actualCounter}`
+    );
+  }
+  const aad = textEncoder.encode(sessionId);
+  try {
+    return new Uint8Array(await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: nonce, additionalData: aad },
+      key,
+      ciphertext
+    ));
+  } catch (err) {
+    throw new Error(`e2e-frame: authentication failed while opening frame (${err.message})`);
+  }
+}
+
+export const E2E_NONCE_LENGTH = NONCE_LENGTH;
+export const E2E_ROLE_TAG_LENGTH = ROLE_TAG_LENGTH;
+
+/**
+ * Deterministic 4-byte role tags for the two sides of one E2E-enabled
+ * connection. Callers pick a role at `enableE2E()` time -- 'initiator'
+ * is naturally the side that called `initiateE2E()` first / sent round-1
+ * KeyExchange, 'responder' the other side; any consistent, non-
+ * overlapping assignment works since these are just fixed structural
+ * tags, not secret values.
+ * @type {Record<'initiator'|'responder', Uint8Array>}
+ */
+export const ROLE_TAGS = Object.freeze({
+  initiator: Uint8Array.from([0x69, 0x6e, 0x69, 0x74]), // "init"
+  responder: Uint8Array.from([0x72, 0x65, 0x73, 0x70]), // "resp"
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1334,6 +1334,9 @@ export class WshSession {
   /** Last terminal diff received for the session. */
   readonly lastTermDiff: Record<string, unknown> | null;
 
+  /** Whether `enableE2E()` has been called and E2E sealing is active for this session. */
+  readonly e2eEnabled: boolean;
+
   constructor(
     transport: WshTransport,
     channelId: number,
@@ -1350,8 +1353,20 @@ export class WshSession {
   /**
    * Write data to the session's stdin stream.
    * Accepts a Uint8Array for raw bytes or a string (UTF-8 encoded).
+   * Sealed into an EncryptedFrame instead of plaintext SessionData when
+   * `enableE2E()` has been called (virtual-mode sessions only).
    */
   write(data: Uint8Array | string): Promise<void>;
+
+  /**
+   * Opt in to end-to-end encryption for this session's data plane
+   * (virtual-mode sessions only). `sharedSecret` must come from a fresh
+   * `WshClient.initiateE2E()` call on the *current* connection --
+   * E2E state is connection-scoped, not session-scoped, so a session
+   * Resumed/Attached on a new connection must run `initiateE2E()` and
+   * `enableE2E()` again rather than reusing a prior key.
+   */
+  enableE2E(sharedSecret: CryptoKey, opts: { role: 'initiator' | 'responder' }): void;
 
   /**
    * Request the remote PTY to resize.

--- a/src/messages.gen.mjs
+++ b/src/messages.gen.mjs
@@ -777,9 +777,10 @@ export function keyExchange({ algorithm, publicKey, sessionId, kemPublicKey, kem
   return msg;
 }
 
-export function encryptedFrame({ nonce, ciphertext, sessionId } = {}) {
+export function encryptedFrame({ channelId, nonce, ciphertext, sessionId } = {}) {
   return {
     type: MSG.ENCRYPTED_FRAME,
+    channel_id: channelId,
     nonce,
     ciphertext,
     session_id: sessionId,

--- a/src/session.mjs
+++ b/src/session.mjs
@@ -9,6 +9,7 @@ import {
   MSG, resize as resizeMsg, signal as signalMsg, close as closeMsg,
 } from './messages.mjs';
 import { WshVirtualSessionBackend } from './virtual-session.mjs';
+import { sealFrame, openFrame, ROLE_TAGS } from './e2e-frame.mjs';
 
 // ── Session states ────────────────────────────────────────────────────
 
@@ -76,6 +77,27 @@ export class WshSession {
 
   /** @type {WshVirtualSessionBackend|null} */
   #virtualBackend = null;
+
+  /**
+   * Non-extractable AES-256-GCM CryptoKey set by `enableE2E()`, or `null`
+   * if E2E is not enabled for this session. Connection-scoped -- see
+   * `enableE2E`'s doc comment for why this must never be reused across a
+   * Resume/Attach.
+   * @type {CryptoKey|null}
+   */
+  #e2eKey = null;
+
+  /** @type {Uint8Array|null} This side's 4-byte nonce role tag, set by `enableE2E()`. */
+  #e2eSendRoleTag = null;
+
+  /** @type {Uint8Array|null} The peer's 4-byte nonce role tag, set by `enableE2E()`. */
+  #e2eRecvRoleTag = null;
+
+  /** @type {number} Next outgoing frame counter for this side. */
+  #e2eSendCounter = 0;
+
+  /** @type {number} Next expected incoming frame counter from the peer. */
+  #e2eRecvCounter = 0;
 
   /**
    * The readable side of the stdout data stream.
@@ -292,6 +314,60 @@ export class WshSession {
     this.#state = STATE_ACTIVE;
   }
 
+  /** Whether `enableE2E()` has been called and E2E sealing is active for this session. */
+  get e2eEnabled() {
+    return this.#e2eKey !== null;
+  }
+
+  /**
+   * Opt in to end-to-end encryption for this session's data plane
+   * (virtual-mode sessions only in this PR; stream-mode is out of
+   * scope -- see `e2e-frame.mjs`'s doc comment). After this call,
+   * `write()` seals outgoing data into `EncryptedFrame` messages instead
+   * of plaintext `SessionData`, and incoming `EncryptedFrame` messages
+   * are opened and delivered via `onData` exactly like `SessionData` is
+   * today; plaintext `SessionData` from a peer is no longer expected
+   * once this side has opted in (it's simply passed through unchanged,
+   * as before -- this method doesn't add any negotiation-failure
+   * handling; that's a later PR).
+   *
+   * IMPORTANT -- key lifetime: `sharedSecret` must come from a *fresh*
+   * `WshClient.initiateE2E()` call on the *current* connection. E2E
+   * state here is connection-scoped, not session-scoped: if this
+   * session is later detached and Resumed/Attached on a new connection,
+   * callers MUST run `initiateE2E()` again and call `enableE2E()` again
+   * with the new key -- never persist or reuse a `sharedSecret` (or its
+   * counters) across a resume. Calling `enableE2E()` again on an
+   * already-enabled session is fine and resets counters cleanly (a
+   * fresh key naturally means fresh counters), but the caller is
+   * responsible for actually supplying a fresh key when doing so.
+   *
+   * @param {CryptoKey} sharedSecret - AES-256-GCM CryptoKey from `WshClient.initiateE2E()`
+   * @param {object} opts
+   * @param {'initiator'|'responder'} opts.role - which side of the KeyExchange this session was;
+   *   determines this side's nonce role tag (see `e2e-frame.mjs`'s `ROLE_TAGS`). The two peers of
+   *   one session MUST pick opposite roles, or their nonces can collide.
+   */
+  enableE2E(sharedSecret, { role } = {}) {
+    if (!sharedSecret || typeof sharedSecret !== 'object') {
+      throw new Error('enableE2E: sharedSecret must be a CryptoKey (see WshClient.initiateE2E)');
+    }
+    if (role !== 'initiator' && role !== 'responder') {
+      throw new Error("enableE2E: opts.role must be 'initiator' or 'responder'");
+    }
+    if (this.#dataMode !== 'virtual') {
+      throw new Error('enableE2E: only virtual-mode sessions are supported in this version (stream-mode is out of scope)');
+    }
+    if (!this.#sessionId) {
+      throw new Error('enableE2E: session has no server-assigned session_id to bind as AAD -- was OPEN_OK missing session_id?');
+    }
+    this.#e2eKey = sharedSecret;
+    this.#e2eSendRoleTag = ROLE_TAGS[role];
+    this.#e2eRecvRoleTag = role === 'initiator' ? ROLE_TAGS.responder : ROLE_TAGS.initiator;
+    this.#e2eSendCounter = 0;
+    this.#e2eRecvCounter = 0;
+  }
+
   // ── Public API ──────────────────────────────────────────────────────
 
   /**
@@ -307,6 +383,15 @@ export class WshSession {
     if (this.#dataMode === 'virtual') {
       if (this.#virtualBackend === null) {
         throw new Error('Session not yet activated — virtual backend unavailable');
+      }
+      if (this.#e2eKey !== null) {
+        const bytes = typeof data === 'string' ? textEncoder.encode(data) : data;
+        const counter = this.#e2eSendCounter++;
+        const { nonce, ciphertext } = await sealFrame(
+          this.#e2eKey, this.#sessionId, this.#e2eSendRoleTag, counter, bytes
+        );
+        await this.#virtualBackend.writeEncrypted({ nonce, ciphertext, sessionId: this.#sessionId });
+        return;
       }
       await this.#virtualBackend.write(data);
       return;
@@ -434,6 +519,40 @@ export class WshSession {
             console.error('[wsh:session] onData handler error:', err);
           }
         }
+        break;
+      }
+
+      case MSG.ENCRYPTED_FRAME: {
+        if (this.#e2eKey === null) {
+          console.error('[wsh:session] received EncryptedFrame but E2E is not enabled on this session — dropping');
+          break;
+        }
+        if (msg.session_id !== this.#sessionId) {
+          console.error('[wsh:session] EncryptedFrame session_id mismatch — dropping (possible splice attempt)');
+          break;
+        }
+        // openFrame is async; _handleControlMessage is a synchronous
+        // dispatch entry point (see the SESSION_DATA case above and its
+        // callers), so this fires the decrypt-and-deliver as a
+        // background task rather than awaiting it here. Per-channel
+        // control messages are already dispatched serially by the
+        // caller (see transport.mjs's dispatchSerially/SerialQueue), so
+        // frames still arrive at openFrame() in wire order; only the
+        // delivery of *this* frame's plaintext to onData is deferred by
+        // one microtask/macrotask relative to synchronous cases.
+        const counter = this.#e2eRecvCounter++;
+        openFrame(this.#e2eKey, this.#sessionId, counter, { nonce: msg.nonce, ciphertext: msg.ciphertext })
+          .then((plaintext) => {
+            this.#virtualBackend?.pushData(plaintext);
+            try {
+              this.onData?.(plaintext);
+            } catch (err) {
+              console.error('[wsh:session] onData handler error:', err);
+            }
+          })
+          .catch((err) => {
+            console.error('[wsh:session] failed to open EncryptedFrame:', err);
+          });
         break;
       }
 

--- a/src/virtual-session.mjs
+++ b/src/virtual-session.mjs
@@ -1,4 +1,4 @@
-import { sessionData as sessionDataMsg } from './messages.mjs';
+import { sessionData as sessionDataMsg, encryptedFrame as encryptedFrameMsg } from './messages.mjs';
 
 const textEncoder = new TextEncoder();
 
@@ -61,6 +61,25 @@ export class WshVirtualSessionBackend {
       sessionDataMsg({
         channelId: this.#channelId,
         data: normalizeSessionData(data),
+      })
+    );
+  }
+
+  /**
+   * Send a pre-sealed EncryptedFrame instead of plaintext SessionData.
+   * Used by `WshSession.write()` when E2E is enabled for this session
+   * (see `session.mjs`'s `enableE2E`).
+   *
+   * @param {{nonce: Uint8Array, ciphertext: Uint8Array, sessionId: string}} frame
+   * @returns {Promise<void>}
+   */
+  async writeEncrypted({ nonce, ciphertext, sessionId }) {
+    await this.#sendControl(
+      encryptedFrameMsg({
+        channelId: this.#channelId,
+        nonce,
+        ciphertext,
+        sessionId,
       })
     );
   }

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -661,3 +661,184 @@ describe('WshClient initiateE2E', { skip: !hasEd25519 && 'Ed25519 not available 
     await assert.rejects(() => assertSameAesKey(hybridResult.sharedSecret, classicalTransport.peerCombinedSecret));
   });
 });
+
+// ── EncryptedFrame end-to-end integration (wsh #19) ───────────────────
+//
+// Wires two *real* WshClient instances together (not one under test
+// against a scripted mock, unlike E2EMockTransport above) so both sides
+// of initiateE2E()'s KeyExchange are the actual production code path,
+// then activates two real WshSession instances in virtual mode and
+// exercises the actual enableE2E()/write()/_handleControlMessage()
+// plumbing this PR adds. An "eavesdropper" observes every control
+// message exchanged between the two sides and asserts the plaintext
+// never appears on the wire.
+
+/**
+ * A transport whose KeyExchange (and, once linked, EncryptedFrame)
+ * control messages are delivered directly to a paired transport's
+ * onControl, simulating a relay that only shuttles opaque control
+ * messages between two peers -- exactly the role a real wsh server
+ * plays for E2E traffic (it relays KeyExchange/EncryptedFrame without
+ * being able to read session content). `wireLog` records every message
+ * that crosses the link, standing in for what an eavesdropping relay
+ * would see on the wire.
+ */
+class E2ELinkedTransport extends WshTransport {
+  #sessionId;
+  #peer = null;
+  wireLog = [];
+
+  constructor(sessionId) {
+    super();
+    this.#sessionId = sessionId;
+  }
+
+  link(peer) {
+    this.#peer = peer;
+  }
+
+  async _doConnect() {}
+  async _doClose() {}
+
+  async _doSendControl(msg) {
+    if (msg.type === MSG.HELLO) {
+      setTimeout(() => this._emitControl({ type: MSG.CHALLENGE, nonce: new Uint8Array(32).fill(7), session_id: this.#sessionId }), 0);
+      return;
+    }
+    if (msg.type === MSG.AUTH) {
+      setTimeout(() => this._emitControl({ type: MSG.AUTH_OK }), 0);
+      return;
+    }
+    if (msg.type === MSG.KEY_EXCHANGE || msg.type === MSG.ENCRYPTED_FRAME) {
+      this.wireLog.push(msg);
+      setTimeout(() => this.#peer?._emitControl(msg), 0);
+    }
+  }
+
+  async _doOpenStream() {
+    throw new Error('not needed for this test');
+  }
+}
+
+describe('EncryptedFrame end-to-end integration', { skip: !hasEd25519 && 'Ed25519 not available in this runtime' }, () => {
+  it('two real WshClient/WshSession pairs exchange sealed data that an eavesdropper on the raw wire cannot read', async () => {
+    const keyPairA = await auth.generateKeyPair(true);
+    const keyPairB = await auth.generateKeyPair(true);
+
+    const transportA = new E2ELinkedTransport('sess-e2e-integ');
+    const transportB = new E2ELinkedTransport('sess-e2e-integ');
+    transportA.link(transportB);
+    transportB.link(transportA);
+
+    const clientA = new clientMod.WshClient({ transportFactories: { ws: () => transportA } });
+    const clientB = new clientMod.WshClient({ transportFactories: { ws: () => transportB } });
+    await clientA.connect('ws://test.invalid', { username: 'alice', keyPair: keyPairA, transport: 'ws' });
+    await clientB.connect('ws://test.invalid', { username: 'bob', keyPair: keyPairB, transport: 'ws' });
+
+    // Real, production initiateE2E() calls on both sides, linked directly
+    // to each other via the transports above -- not a scripted mock peer.
+    const [resultA, resultB] = await Promise.all([
+      clientA.initiateE2E('sess-e2e-integ', 'X25519', 30_000),
+      clientB.initiateE2E('sess-e2e-integ', 'X25519', 30_000),
+    ]);
+    assert.equal(resultA.hybrid, false);
+    assert.equal(resultB.hybrid, false);
+
+    // Build two WshSession instances directly in virtual mode, wired to
+    // each other exactly like transportA/transportB above -- standing in
+    // for the relay a real server would provide between two session
+    // participants without being able to read the content.
+    const sessionModule = await import('../src/session.mjs');
+    const { WshSession } = sessionModule;
+
+    const dummyTransport = { sendControl: async () => {} };
+    const sessionA = new WshSession(dummyTransport, 1, {}, 'pty', { dataMode: 'virtual', sessionId: 'sess-e2e-integ' });
+    const sessionB = new WshSession(dummyTransport, 1, {}, 'pty', { dataMode: 'virtual', sessionId: 'sess-e2e-integ' });
+
+    const wireLog = [];
+    sessionA._activateVirtual(async (msg) => {
+      wireLog.push(msg);
+      sessionB._handleControlMessage(msg);
+    });
+    sessionB._activateVirtual(async (msg) => {
+      wireLog.push(msg);
+      sessionA._handleControlMessage(msg);
+    });
+
+    sessionA.enableE2E(resultA.sharedSecret, { role: 'initiator' });
+    sessionB.enableE2E(resultB.sharedSecret, { role: 'responder' });
+
+    const plaintext = 'this is a secret message from A to B';
+    const received = new Promise((resolve) => {
+      sessionB.onData = (data) => resolve(new TextDecoder().decode(data));
+    });
+
+    await sessionA.write(plaintext);
+    const receivedText = await received;
+
+    assert.equal(receivedText, plaintext);
+
+    // The eavesdropper (wireLog, standing in for a relay/server reading
+    // raw control-message bytes) must never see the plaintext, or any
+    // substring of it, in the frame it observed.
+    assert.equal(wireLog.length, 1);
+    const frame = wireLog[0];
+    assert.equal(frame.type, MSG.ENCRYPTED_FRAME);
+    const ciphertextAsLatin1 = Buffer.from(frame.ciphertext).toString('latin1');
+    assert.equal(ciphertextAsLatin1.includes(plaintext), false);
+    // Also confirm the raw nonce+ciphertext bytes, concatenated, don't
+    // contain the plaintext -- belt-and-suspenders over the ciphertext-
+    // only check above.
+    const wireBytes = Buffer.concat([Buffer.from(frame.nonce), Buffer.from(frame.ciphertext)]).toString('latin1');
+    assert.equal(wireBytes.includes(plaintext), false);
+  });
+
+  it('a tampered EncryptedFrame on the wire is silently dropped, not delivered as corrupted plaintext', async () => {
+    const keyPairA = await auth.generateKeyPair(true);
+    const keyPairB = await auth.generateKeyPair(true);
+
+    const transportA = new E2ELinkedTransport('sess-e2e-tamper');
+    const transportB = new E2ELinkedTransport('sess-e2e-tamper');
+    transportA.link(transportB);
+    transportB.link(transportA);
+
+    const clientA = new clientMod.WshClient({ transportFactories: { ws: () => transportA } });
+    const clientB = new clientMod.WshClient({ transportFactories: { ws: () => transportB } });
+    await clientA.connect('ws://test.invalid', { username: 'alice', keyPair: keyPairA, transport: 'ws' });
+    await clientB.connect('ws://test.invalid', { username: 'bob', keyPair: keyPairB, transport: 'ws' });
+
+    const [resultA, resultB] = await Promise.all([
+      clientA.initiateE2E('sess-e2e-tamper', 'X25519', 30_000),
+      clientB.initiateE2E('sess-e2e-tamper', 'X25519', 30_000),
+    ]);
+
+    const sessionModule = await import('../src/session.mjs');
+    const { WshSession } = sessionModule;
+    const dummyTransport = { sendControl: async () => {} };
+    const sessionA = new WshSession(dummyTransport, 1, {}, 'pty', { dataMode: 'virtual', sessionId: 'sess-e2e-tamper' });
+    const sessionB = new WshSession(dummyTransport, 1, {}, 'pty', { dataMode: 'virtual', sessionId: 'sess-e2e-tamper' });
+
+    sessionA._activateVirtual(async (msg) => {
+      // Flip a ciphertext byte before delivery, simulating an active
+      // tamperer on the wire.
+      if (msg.type === MSG.ENCRYPTED_FRAME) {
+        msg.ciphertext = msg.ciphertext.slice();
+        msg.ciphertext[0] ^= 0xff;
+      }
+      sessionB._handleControlMessage(msg);
+    });
+    sessionB._activateVirtual(async (msg) => sessionA._handleControlMessage(msg));
+
+    sessionA.enableE2E(resultA.sharedSecret, { role: 'initiator' });
+    sessionB.enableE2E(resultB.sharedSecret, { role: 'responder' });
+
+    let delivered = false;
+    sessionB.onData = () => { delivered = true; };
+
+    await sessionA.write('will be tampered with');
+    // Give the async openFrame()/catch() a turn to run.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    assert.equal(delivered, false);
+  });
+});

--- a/test/e2e-frame.test.mjs
+++ b/test/e2e-frame.test.mjs
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { sealFrame, openFrame, buildNonce, ROLE_TAGS, E2E_NONCE_LENGTH } from '../src/e2e-frame.mjs';
+
+const hasWebCrypto = typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined';
+
+async function makeKey() {
+  const raw = crypto.getRandomValues(new Uint8Array(32));
+  return crypto.subtle.importKey('raw', raw, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']);
+}
+
+describe('e2e-frame', { skip: !hasWebCrypto && 'WebCrypto not available in this runtime' }, () => {
+  it('sealFrame/openFrame round-trip correctly', async () => {
+    const key = await makeKey();
+    const plaintext = new TextEncoder().encode('hello from the initiator');
+
+    const frame = await sealFrame(key, 'session-a', ROLE_TAGS.initiator, 0, plaintext);
+    assert.equal(frame.nonce.length, E2E_NONCE_LENGTH);
+
+    const opened = await openFrame(key, 'session-a', 0, frame);
+    assert.deepEqual([...opened], [...plaintext]);
+  });
+
+  it('round-trips multiple sequential frames with increasing counters', async () => {
+    const key = await makeKey();
+    const messages = ['one', 'two', 'three'].map((s) => new TextEncoder().encode(s));
+
+    const frames = [];
+    for (let i = 0; i < messages.length; i++) {
+      frames.push(await sealFrame(key, 'session-b', ROLE_TAGS.initiator, i, messages[i]));
+    }
+    for (let i = 0; i < messages.length; i++) {
+      const opened = await openFrame(key, 'session-b', i, frames[i]);
+      assert.deepEqual([...opened], [...messages[i]]);
+    }
+  });
+
+  it('tamper detection: a flipped ciphertext byte fails to open', async () => {
+    const key = await makeKey();
+    const plaintext = new TextEncoder().encode('do not tamper with me');
+    const frame = await sealFrame(key, 'session-c', ROLE_TAGS.initiator, 0, plaintext);
+
+    const tampered = { nonce: frame.nonce, ciphertext: frame.ciphertext.slice() };
+    tampered.ciphertext[0] ^= 0xff;
+
+    await assert.rejects(() => openFrame(key, 'session-c', 0, tampered));
+  });
+
+  it('tamper detection: a flipped AAD (session_id) fails to open', async () => {
+    const key = await makeKey();
+    const plaintext = new TextEncoder().encode('bound to session-d only');
+    const frame = await sealFrame(key, 'session-d', ROLE_TAGS.initiator, 0, plaintext);
+
+    // Attempting to open under a different session_id (simulating a
+    // relay splicing ciphertext from one session onto another) must fail.
+    await assert.rejects(() => openFrame(key, 'session-e', 0, frame));
+  });
+
+  it('replay/reorder rejection: an out-of-order or replayed counter is rejected', async () => {
+    const key = await makeKey();
+    const plaintext = new TextEncoder().encode('sequenced message');
+
+    const frame0 = await sealFrame(key, 'session-f', ROLE_TAGS.initiator, 0, plaintext);
+    const frame1 = await sealFrame(key, 'session-f', ROLE_TAGS.initiator, 1, plaintext);
+
+    // Replaying frame0 when counter 1 is expected must fail.
+    await assert.rejects(() => openFrame(key, 'session-f', 1, frame0));
+    // Skipping ahead (frame1 when 0 is expected) must also fail.
+    await assert.rejects(() => openFrame(key, 'session-f', 0, frame1));
+    // The correctly-ordered sequence succeeds.
+    await openFrame(key, 'session-f', 0, frame0);
+    await openFrame(key, 'session-f', 1, frame1);
+  });
+
+  it('wrong key fails to open (authentication failure, not silent success)', async () => {
+    const key = await makeKey();
+    const otherKey = await makeKey();
+    const plaintext = new TextEncoder().encode('secret');
+    const frame = await sealFrame(key, 'session-g', ROLE_TAGS.initiator, 0, plaintext);
+
+    await assert.rejects(() => openFrame(otherKey, 'session-g', 0, frame));
+  });
+
+  it('nonce uniqueness: two consecutive seals from the same sender never produce the same nonce', async () => {
+    const key = await makeKey();
+    const plaintext = new TextEncoder().encode('x');
+
+    const frameA = await sealFrame(key, 'session-h', ROLE_TAGS.initiator, 0, plaintext);
+    const frameB = await sealFrame(key, 'session-h', ROLE_TAGS.initiator, 1, plaintext);
+
+    assert.notDeepEqual([...frameA.nonce], [...frameB.nonce]);
+  });
+
+  it('nonce uniqueness: the two peers of a session cannot collide even at the same counter (distinct role tags)', async () => {
+    const initiatorNonce = buildNonce(0, ROLE_TAGS.initiator);
+    const responderNonce = buildNonce(0, ROLE_TAGS.responder);
+
+    assert.notDeepEqual([...initiatorNonce], [...responderNonce]);
+  });
+
+  it('buildNonce lays out an 8-byte big-endian counter followed by the 4-byte role tag', () => {
+    const nonce = buildNonce(1, ROLE_TAGS.initiator);
+    assert.equal(nonce.length, 12);
+    // First 8 bytes: big-endian counter = 1.
+    assert.deepEqual([...nonce.slice(0, 8)], [0, 0, 0, 0, 0, 0, 0, 1]);
+    // Last 4 bytes: the role tag, verbatim.
+    assert.deepEqual([...nonce.slice(8, 12)], [...ROLE_TAGS.initiator]);
+  });
+
+  it('openFrame rejects a malformed nonce length rather than misbehaving', async () => {
+    const key = await makeKey();
+    await assert.rejects(() => openFrame(key, 'session-i', 0, { nonce: new Uint8Array(4), ciphertext: new Uint8Array(16) }));
+  });
+});


### PR DESCRIPTION
## Summary

PR 1 of 4 in the real end-to-end encryption rollout for the wsh protocol. Implements the AEAD seal/open primitives for `EncryptedFrame` and wires them into virtual-mode session data (the mode clawser's remote terminal actually uses). Stream-mode sessions and cross-language (Rust) `EncryptedFrame` support are out of scope for this PR — see PR 2+ in the clawser repo.

- **`src/e2e-frame.mjs`** (new): `sealFrame(key, sessionId, roleTag, counter, plaintext)` / `openFrame(key, sessionId, expectedCounter, {nonce, ciphertext})` over AES-256-GCM, matching the key `WshClient.initiateE2E()` already derives (`src/client.mjs`).
  - **Nonce**: 12 bytes = 8-byte big-endian monotonic counter + 4-byte fixed per-sender role tag (`ROLE_TAGS.initiator` / `ROLE_TAGS.responder`), so the two peers of one session structurally cannot collide even under fully concurrent bidirectional traffic.
  - **AAD**: `session_id` (UTF-8) is bound as AES-GCM additional authenticated data — authenticated but unencrypted, so a relay can't splice ciphertext from one session onto another.
  - **Replay/reorder**: `openFrame` requires the frame's counter to be *exactly* the expected next value; anything else (replay, drop, reorder) is rejected outright. Documented as intentionally strict for v1.
- **`src/session.mjs`**: opt-in `WshSession.enableE2E(sharedSecret, { role })` — sets connection-scoped key/counters. When enabled, `write()` seals into `EncryptedFrame` instead of plaintext `SessionData`, and `_handleControlMessage()` opens incoming `EncryptedFrame` into the existing `onData` callback. Documented explicitly: E2E state is connection-scoped, never reuse a `sharedSecret` across a session Resume/Attach — always re-run `initiateE2E()`.
- **`src/virtual-session.mjs`**: new `WshVirtualSessionBackend.writeEncrypted()` to send sealed frames.
- **`spec/wsh-v1.yaml`**: `EncryptedFrame` was missing a `channel_id` field needed to route incoming frames to the right session (unlike `SessionData`, which already has one) — added and regenerated via `spec/codegen.mjs` (JS + spec markdown only; the Rust codegen target lives in a separate repo and was **not** touched by this PR). Also corrected the stale doc comment claiming the Rust client has no E2E support at all — it now has `initiate_e2e`; `EncryptedFrame` sealing there is still a separate follow-up.
- Stays fully opt-in: existing plaintext `SessionData` behavior is unchanged unless a caller explicitly calls `enableE2E()`.

## Test plan

- [x] `node --test test/*.test.mjs` — 409 → 421 tests, all green (no regressions).
- [x] `test/e2e-frame.test.mjs` (new): round-trip correctness, ciphertext tamper detection, AAD (session_id) tamper detection, replay/reorder rejection, wrong-key rejection, nonce uniqueness (same sender consecutive counters; same counter across the two roles), nonce byte layout, malformed-nonce rejection.
- [x] `test/client.test.mjs` (extended): full integration — two real `WshClient` instances perform a real `initiateE2E()` handshake against each other (not a scripted mock), then two real `WshSession`s in virtual mode call `enableE2E()` and exchange data; asserts the eavesdropping "wire" never contains the plaintext (checked against both ciphertext alone and nonce+ciphertext together), and that a tampered frame is dropped rather than delivered as corrupted plaintext.