### PR TITLE
Seal stream-mode sessions with AES-256-GCM chunk framing (PR 1 of 3, wsh #22)

### DIFF
--- a/spec/wsh-v1.yaml
+++ b/spec/wsh-v1.yaml
@@ -1294,23 +1294,35 @@ messages:
 
   # ── E2E encryption (EXPERIMENTAL) ─────────────────────────────────────
   # Inner encryption layer intended for end-to-end confidentiality: after
-  # key exchange, session data is wrapped in EncryptedFrame messages so
-  # the server cannot read session content. Status per side of the wire:
+  # key exchange, session data is protected so the server cannot read
+  # session content. Status per side of the wire:
   # WshClient.initiateE2E() performs a real X25519 ECDH exchange
   # (optionally hybrid with ML-KEM-768, see below) and derives an
   # AES-256-GCM key (src/client.mjs); as of this JS library's
-  # EncryptedFrame support (wsh #19), that key is now actually used to
-  # seal/open virtual-mode session data via WshSession.enableE2E()
-  # (src/session.mjs, src/e2e-frame.mjs) -- stream-mode sessions (raw
-  # byte streams, no message boundaries) aren't wired up yet. The Rust
-  # client (clawser's wsh-client crate) does have KeyExchange/
+  # EncryptedFrame support (wsh #19), that key is used to seal/open
+  # virtual-mode session data (discrete SessionData control messages
+  # swapped 1:1 for EncryptedFrame) via WshSession.enableE2E()
+  # (src/session.mjs, src/e2e-frame.mjs). As of wsh #22 (PR 1 of a
+  # 3-PR rollout), the same key/enableE2E() call also covers
+  # stream-mode sessions (raw byte streams, no message boundaries):
+  # sealed chunks are framed *inline in the raw stream itself* --
+  # [4-byte big-endian length][12-byte nonce][ciphertext + 16-byte GCM
+  # tag] -- reusing the exact same sealFrame/openFrame primitives and
+  # nonce scheme as EncryptedFrame, just without a CBOR envelope. This
+  # inline chunk framing is invisible to this control-message spec: it
+  # lives entirely inside the byte stream a session's data plane already
+  # carries, so it introduces no new message type here (see
+  # src/stream-frame.mjs for the framing/reassembly implementation).
+  # The Rust client (clawser's wsh-client crate) does have KeyExchange/
   # initiate_e2e support, but does not yet construct or consume
-  # EncryptedFrame -- that AEAD sealing is tracked as a separate
-  # follow-up in that repo. The Rust server only relays both message
-  # types opaquely between session participants (correct for true E2E,
+  # EncryptedFrame or stream-mode chunk framing -- that AEAD sealing is
+  # tracked as a separate follow-up in that repo (wsh #22's PR 2/PR 3).
+  # The Rust server only relays both message types (and raw stream
+  # bytes) opaquely between session participants (correct for true E2E,
   # but doesn't imply either side actually encrypts). Do not rely on
   # this for confidentiality against a peer that hasn't actually called
-  # enableE2E()/opened an EncryptedFrame-sealing equivalent.
+  # enableE2E()/opened an EncryptedFrame-sealing (or stream chunk
+  # framing) equivalent.
   e2e:
     KeyExchange:
       code: 0x8e
@@ -1365,7 +1377,13 @@ messages:
       description: >
         An encrypted payload carrying virtual-mode session data, once
         KeyExchange's derived secret is wired to real encryption via
-        WshSession.enableE2E() (see the e2e section note above). Sent
+        WshSession.enableE2E() (see the e2e section note above).
+        Virtual-mode only -- stream-mode sessions never send this
+        message type; their sealed data instead travels as inline
+        length-prefixed chunks inside the raw byte stream itself (see
+        the e2e section note above and src/stream-frame.mjs), since a
+        stream-mode session has no control-message channel to carry a
+        CBOR envelope like this one through. Sent
         using AES-256-GCM AEAD, matching the cipher
         WshClient.initiateE2E() derives a key for (src/client.mjs) --
         picked over the ChaCha20-Poly1305 this field previously

--- a/src/e2e-frame.mjs
+++ b/src/e2e-frame.mjs
@@ -4,11 +4,15 @@
  * `CryptoKey` this module seals/opens with, and `spec/wsh-v1.yaml`'s
  * `EncryptedFrame` message).
  *
- * This is PR 1 of a multi-PR E2E rollout: it implements the AEAD
- * primitives and wires them into virtual-mode sessions only (see
- * `session.mjs`'s `enableE2E`). Stream-mode sessions (raw WebTransport
- * byte streams with no message boundaries) are explicitly out of scope
- * here -- they need separate ad hoc chunk-framing design.
+ * This module's AEAD primitives were introduced in wsh #19 (virtual-mode
+ * only) and, as of wsh #22 (PR 1 of 3), are reused unchanged by
+ * stream-mode sessions too: `stream-frame.mjs` wraps `sealFrame`/
+ * `openFrame` in inline length-prefixed chunk framing for raw
+ * WebTransport byte streams (no message boundaries), while
+ * `session.mjs`'s `enableE2E` now dispatches to either transport based
+ * on the session's `dataMode`. This module itself needed no changes for
+ * that -- see `stream-frame.mjs`'s doc comment for the chunk-framing
+ * design.
  *
  * ── Nonce construction ─────────────────────────────────────────────
  * Nonces are the AES-GCM-mandated 96 bits (12 bytes), built as:

--- a/src/session.mjs
+++ b/src/session.mjs
@@ -10,6 +10,9 @@ import {
 } from './messages.mjs';
 import { WshVirtualSessionBackend } from './virtual-session.mjs';
 import { sealFrame, openFrame, ROLE_TAGS } from './e2e-frame.mjs';
+import {
+  ChunkAccumulator, encodeChunk, resolveCoalesceOptions, WriteCoalescer, StreamAuthenticationError,
+} from './stream-frame.mjs';
 
 // ── Session states ────────────────────────────────────────────────────
 
@@ -98,6 +101,22 @@ export class WshSession {
 
   /** @type {number} Next expected incoming frame counter from the peer. */
   #e2eRecvCounter = 0;
+
+  /**
+   * Reassembles the raw stdout byte stream into complete sealed chunks
+   * when E2E is enabled on a stream-mode session. `null` for virtual-mode
+   * sessions or when E2E is not enabled.
+   * @type {import('./stream-frame.mjs').ChunkAccumulator|null}
+   */
+  #streamAccumulator = null;
+
+  /**
+   * Batches outgoing stream-mode writes before sealing, per the
+   * write-coalescing design (wsh #22). `null` means coalescing is
+   * disabled (`coalesce: false`) -- every write() seals immediately.
+   * @type {WriteCoalescer|null}
+   */
+  #streamCoalescer = null;
 
   /**
    * The readable side of the stdout data stream.
@@ -320,16 +339,26 @@ export class WshSession {
   }
 
   /**
-   * Opt in to end-to-end encryption for this session's data plane
-   * (virtual-mode sessions only in this PR; stream-mode is out of
-   * scope -- see `e2e-frame.mjs`'s doc comment). After this call,
-   * `write()` seals outgoing data into `EncryptedFrame` messages instead
-   * of plaintext `SessionData`, and incoming `EncryptedFrame` messages
-   * are opened and delivered via `onData` exactly like `SessionData` is
-   * today; plaintext `SessionData` from a peer is no longer expected
-   * once this side has opted in (it's simply passed through unchanged,
-   * as before -- this method doesn't add any negotiation-failure
-   * handling; that's a later PR).
+   * Opt in to end-to-end encryption for this session's data plane.
+   * Works for both virtual-mode and stream-mode sessions (wsh #22
+   * generalized this from virtual-mode-only, #19).
+   *
+   * Virtual-mode: after this call, `write()` seals outgoing data into
+   * `EncryptedFrame` control messages instead of plaintext
+   * `SessionData`, and incoming `EncryptedFrame` messages are opened and
+   * delivered via `onData` exactly like `SessionData` is today;
+   * plaintext `SessionData` from a peer is no longer expected once this
+   * side has opted in (it's simply passed through unchanged, as before
+   * -- this method doesn't add any negotiation-failure handling; that's
+   * a later PR).
+   *
+   * Stream-mode: outgoing bytes are sealed and framed inline in the raw
+   * byte stream (`stream-frame.mjs`'s `[len][nonce][ciphertext]` chunk
+   * format, reusing the same `sealFrame`/`openFrame` primitives) --
+   * invisible to the control-message spec, no new CBOR message type.
+   * Small writes are batched before sealing per `opts.coalesce` (see
+   * below); incoming bytes are reassembled via a `ChunkAccumulator` and
+   * opened per-chunk before reaching `onData`.
    *
    * IMPORTANT -- key lifetime: `sharedSecret` must come from a *fresh*
    * `WshClient.initiateE2E()` call on the *current* connection. E2E
@@ -347,16 +376,17 @@ export class WshSession {
    * @param {'initiator'|'responder'} opts.role - which side of the KeyExchange this session was;
    *   determines this side's nonce role tag (see `e2e-frame.mjs`'s `ROLE_TAGS`). The two peers of
    *   one session MUST pick opposite roles, or their nonces can collide.
+   * @param {false|{maxBytes?: number, maxDelayMs?: number}} [opts.coalesce] - stream-mode only:
+   *   override the default write-coalescing profile derived from this session's `kind`
+   *   ('pty'|'exec'), or pass `false` to seal every write() immediately with no batching.
+   *   Ignored for virtual-mode sessions (each write() is already one EncryptedFrame).
    */
-  enableE2E(sharedSecret, { role } = {}) {
+  enableE2E(sharedSecret, { role, coalesce } = {}) {
     if (!sharedSecret || typeof sharedSecret !== 'object') {
       throw new Error('enableE2E: sharedSecret must be a CryptoKey (see WshClient.initiateE2E)');
     }
     if (role !== 'initiator' && role !== 'responder') {
       throw new Error("enableE2E: opts.role must be 'initiator' or 'responder'");
-    }
-    if (this.#dataMode !== 'virtual') {
-      throw new Error('enableE2E: only virtual-mode sessions are supported in this version (stream-mode is out of scope)');
     }
     if (!this.#sessionId) {
       throw new Error('enableE2E: session has no server-assigned session_id to bind as AAD -- was OPEN_OK missing session_id?');
@@ -366,6 +396,75 @@ export class WshSession {
     this.#e2eRecvRoleTag = role === 'initiator' ? ROLE_TAGS.responder : ROLE_TAGS.initiator;
     this.#e2eSendCounter = 0;
     this.#e2eRecvCounter = 0;
+
+    if (this.#dataMode === 'stream') {
+      // Two-data-plane counter isolation note: send/recv counters above
+      // are per-session (this instance), not shared with any other data
+      // plane -- a session is always exactly one of stream/virtual today,
+      // so there's nothing to cross-wire, but a future refactor that let
+      // one session span both planes simultaneously would need separate
+      // counters per plane.
+      this.#streamAccumulator = new ChunkAccumulator();
+      const profile = resolveCoalesceOptions(this.kind, coalesce);
+      this.#streamCoalescer = profile
+        ? new WriteCoalescer(profile, (bytes) => this.#sealAndWriteStreamChunk(bytes))
+        : null;
+    } else {
+      this.#streamAccumulator = null;
+      this.#streamCoalescer = null;
+    }
+  }
+
+  /**
+   * Seal one stream-mode chunk and write it to the stdin stream. Used
+   * directly by write() when coalescing is disabled, and as the flush
+   * callback for `#streamCoalescer` otherwise.
+   * @private
+   */
+  async #sealAndWriteStreamChunk(bytes) {
+    if (this.#stdinWriter === null) {
+      throw new Error('Session not yet bound — stdin writer unavailable');
+    }
+    const counter = this.#e2eSendCounter++;
+    const { nonce, ciphertext } = await sealFrame(
+      this.#e2eKey, this.#sessionId, this.#e2eSendRoleTag, counter, bytes
+    );
+    await this.#stdinWriter.write(encodeChunk(nonce, ciphertext));
+  }
+
+  /**
+   * Feed newly-read bytes through the stream E2E accumulator and open
+   * every complete chunk it yields.
+   *
+   * @param {Uint8Array} bytes
+   * @returns {Promise<Uint8Array[]|null>} the opened plaintext chunks, in order,
+   *   or `null` if framing was corrupt or a chunk failed authentication
+   *   (already logged; caller should tear the pump down).
+   * @private
+   */
+  async #openStreamChunks(bytes) {
+    let wireChunks;
+    try {
+      wireChunks = this.#streamAccumulator.feed(bytes);
+    } catch (err) {
+      console.error('[wsh:session] stream E2E framing error:', err);
+      return null;
+    }
+    const plaintexts = [];
+    for (const { nonce, ciphertext } of wireChunks) {
+      const counter = this.#e2eRecvCounter++;
+      try {
+        const plaintext = await openFrame(this.#e2eKey, this.#sessionId, counter, { nonce, ciphertext });
+        plaintexts.push(plaintext);
+      } catch (err) {
+        console.error(
+          '[wsh:session] stream E2E chunk failed authentication:',
+          new StreamAuthenticationError(err.message)
+        );
+        return null;
+      }
+    }
+    return plaintexts;
   }
 
   // ── Public API ──────────────────────────────────────────────────────
@@ -401,6 +500,16 @@ export class WshSession {
     }
 
     const bytes = typeof data === 'string' ? textEncoder.encode(data) : data;
+
+    if (this.#e2eKey !== null) {
+      if (this.#streamCoalescer) {
+        await this.#streamCoalescer.write(bytes);
+      } else {
+        await this.#sealAndWriteStreamChunk(bytes);
+      }
+      return;
+    }
+
     await this.#stdinWriter.write(bytes);
   }
 
@@ -482,6 +591,16 @@ export class WshSession {
     }
 
     if (this.#dataMode === 'stream') {
+      // Flush any bytes still batched by write-coalescing before closing
+      // the writer, so a pending buffer isn't silently dropped.
+      if (this.#streamCoalescer) {
+        try {
+          await this.#streamCoalescer.flush();
+        } catch (err) {
+          console.error('[wsh:session] failed to flush coalesced stream E2E writes on close:', err);
+        }
+      }
+
       // Release the stdin writer.
       try {
         await this.#stdinWriter?.close();
@@ -710,13 +829,44 @@ export class WshSession {
         if (this.#abort.signal.aborted) break;
 
         const { done, value } = await reader.read();
-        if (done) break;
+        if (done) {
+          // Clean EOF: catch a torn (truncated) chunk left in the E2E
+          // accumulator, if any -- per the design, no partial-chunk
+          // plaintext is ever released, so this is purely a diagnostic
+          // (the stream is ending either way).
+          if (this.#e2eKey !== null && this.#streamAccumulator) {
+            try {
+              this.#streamAccumulator.finish();
+            } catch (err) {
+              console.error('[wsh:session] stream E2E torn chunk at stream end:', err);
+            }
+          }
+          break;
+        }
 
         if (value && value.byteLength > 0) {
-          try {
-            this.onData?.(value);
-          } catch (err) {
-            console.error('[wsh:session] onData handler error:', err);
+          if (this.#e2eKey !== null && this.#streamAccumulator) {
+            const deliverable = await this.#openStreamChunks(value);
+            if (deliverable === null) {
+              // Authentication failure (or corrupt framing) -- matches
+              // the strict "no skip-and-continue" philosophy of
+              // virtual-mode's counter check: tear the session down
+              // rather than deliver anything from this point on.
+              break;
+            }
+            for (const plaintext of deliverable) {
+              try {
+                this.onData?.(plaintext);
+              } catch (err) {
+                console.error('[wsh:session] onData handler error:', err);
+              }
+            }
+          } else {
+            try {
+              this.onData?.(value);
+            } catch (err) {
+              console.error('[wsh:session] onData handler error:', err);
+            }
           }
         }
       }

--- a/src/stream-frame.mjs
+++ b/src/stream-frame.mjs
@@ -1,0 +1,372 @@
+/**
+ * Stream-mode chunk framing for wsh's opt-in end-to-end encryption layer
+ * (see `session.mjs`'s `enableE2E`, which now accepts stream-backed
+ * sessions -- this module supplies the framing wrapper that makes that
+ * possible; the AEAD primitives themselves live in `e2e-frame.mjs` and
+ * are reused unchanged).
+ *
+ * This is PR 1 of 3 in the stream-mode E2E rollout (wsh #22, follow-up
+ * to the virtual-mode rollout in #19). See that issue for the full
+ * design doc; the short version below is enough to work on this module.
+ *
+ * ── Why framing is needed at all ──────────────────────────────────────
+ * Stream-mode sessions are raw WebTransport bidirectional byte streams
+ * with no message boundaries (`transport.mjs`'s `openStream()`: "Data
+ * streams carry raw bytes with no framing overhead"). Virtual-mode reuses
+ * the control-message envelope (`EncryptedFrame`) to carry one sealed
+ * frame per `SessionData` 1:1, but a byte stream has no such envelope --
+ * a single `read()` may return a partial chunk, multiple chunks, or a
+ * chunk split across two reads. This module's `ChunkAccumulator` restores
+ * chunk boundaries on the read side; `encodeChunk` builds them on the
+ * write side.
+ *
+ * ── Wire format ────────────────────────────────────────────────────────
+ *
+ *   [ 4-byte big-endian length prefix N ][ 12-byte nonce ][ N bytes: ciphertext + 16-byte GCM tag ]
+ *
+ * - N counts only the ciphertext+tag bytes that follow the nonce (the
+ *   nonce itself is a fixed 12-byte wire constant, not counted -- avoids
+ *   an off-by-12 footgun).
+ * - The nonce is 12 bytes, clear (not secret -- same convention as
+ *   virtual-mode's `EncryptedFrame.nonce`); it encodes the same
+ *   8-byte-counter + 4-byte-role-tag scheme from `e2e-frame.mjs`, reused
+ *   verbatim: a stream "chunk index" is exactly the same thing as
+ *   virtual-mode's "message counter" (see `buildNonce`/`ROLE_TAGS`).
+ * - The length field is NOT bound as AEAD additional authenticated data:
+ *   there's no tampering scenario it prevents that the GCM tag doesn't
+ *   already catch -- a corrupted length either fails decryption outright
+ *   or misaligns the *next* chunk's boundary, but plaintext is never
+ *   released without passing authentication either way.
+ * - Chunk size: soft target ~16 KiB plaintext, hard cap 64 KiB (a `u32`
+ *   length prefix has ample headroom above that). See `resolveCoalesceOptions`
+ *   for how writes are batched up to (well below) that cap before sealing.
+ *
+ * ── Failure modes at stream end ───────────────────────────────────────
+ * `ChunkAccumulator` distinguishes:
+ *  1. Clean EOF -- buffer empty when `finish()` is called.
+ *  2. Torn chunk -- partial bytes buffered (not enough for a complete
+ *     chunk) when `finish()` is called -- throws `StreamTornChunkError`.
+ *  3. Failed AEAD authentication on an otherwise-complete chunk -- this
+ *     is *not* raised by this module (it has no key); callers use
+ *     `StreamAuthenticationError` to report it after calling `openFrame`
+ *     from `e2e-frame.mjs` (see `session.mjs`'s stream read path).
+ * No partial-chunk plaintext is ever released in any case.
+ *
+ * ── Efficiency note ────────────────────────────────────────────────────
+ * `ChunkAccumulator` uses a cursor-based internal buffer (append via an
+ * amortized-doubling growable `Uint8Array`, consume via advancing a read
+ * offset) rather than repeatedly `Uint8Array.slice()`-ing the whole
+ * buffer on every `feed()` call, which would go quadratic under many
+ * small `read()`s. The only per-chunk `slice()` calls are for the two
+ * pieces (`nonce`, `ciphertext`) actually handed back to the caller.
+ */
+
+import { sealFrame } from './e2e-frame.mjs';
+
+const LENGTH_PREFIX_BYTES = 4;
+const NONCE_BYTES = 12;
+const GCM_TAG_BYTES = 16;
+
+/** Soft target plaintext chunk size (see module doc comment). */
+export const CHUNK_SOFT_TARGET_BYTES = 16 * 1024;
+
+/** Hard cap on plaintext chunk size; ciphertext+tag never exceeds this + 16. */
+export const CHUNK_HARD_CAP_BYTES = 64 * 1024;
+
+/**
+ * Sanity bound on the wire length prefix, used only to fail fast on an
+ * obviously-corrupt/malicious length field (e.g. a torn/garbled header)
+ * rather than buffering unboundedly while waiting for a chunk that will
+ * never complete. Generous headroom above `CHUNK_HARD_CAP_BYTES` so a
+ * legitimate sender is never rejected.
+ */
+const MAX_WIRE_CIPHERTEXT_BYTES = CHUNK_HARD_CAP_BYTES + GCM_TAG_BYTES;
+
+/**
+ * Thrown by `ChunkAccumulator.finish()` when the internal buffer still
+ * holds partial (incomplete) chunk bytes at stream EOF -- a truncated
+ * stream, not a clean close. Distinct from `StreamAuthenticationError`
+ * so callers can tell "the stream ended mid-chunk" apart from "a
+ * complete chunk arrived but failed to authenticate".
+ */
+export class StreamTornChunkError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'StreamTornChunkError';
+  }
+}
+
+/**
+ * Thrown by callers (see `session.mjs`'s stream read path) when a
+ * complete, well-framed chunk fails AEAD authentication in
+ * `openFrame()` (tampered ciphertext, wrong key, or session_id
+ * mismatch). Distinct from `StreamTornChunkError` -- this module itself
+ * never throws it, since `ChunkAccumulator` has no key and cannot
+ * authenticate anything.
+ */
+export class StreamAuthenticationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'StreamAuthenticationError';
+  }
+}
+
+/**
+ * Encode one sealed chunk for the wire: `[len][nonce][ciphertext]`.
+ *
+ * @param {Uint8Array} nonce - exactly 12 bytes
+ * @param {Uint8Array} ciphertext - ciphertext + GCM tag, as returned by `sealFrame`
+ * @returns {Uint8Array}
+ */
+export function encodeChunk(nonce, ciphertext) {
+  if (!(nonce instanceof Uint8Array) || nonce.length !== NONCE_BYTES) {
+    throw new Error(`stream-frame: nonce must be a ${NONCE_BYTES}-byte Uint8Array`);
+  }
+  if (!(ciphertext instanceof Uint8Array)) {
+    throw new Error('stream-frame: ciphertext must be a Uint8Array');
+  }
+  const out = new Uint8Array(LENGTH_PREFIX_BYTES + NONCE_BYTES + ciphertext.length);
+  new DataView(out.buffer).setUint32(0, ciphertext.length, false);
+  out.set(nonce, LENGTH_PREFIX_BYTES);
+  out.set(ciphertext, LENGTH_PREFIX_BYTES + NONCE_BYTES);
+  return out;
+}
+
+/**
+ * Reassembles a raw byte stream into complete `{nonce, ciphertext}`
+ * chunks. See the module doc comment for the wire format and the
+ * efficiency note on the internal buffer strategy.
+ */
+export class ChunkAccumulator {
+  /** @type {Uint8Array} */
+  #buf = new Uint8Array(0);
+  /** @type {number} Read cursor -- bytes before this offset are already consumed. */
+  #start = 0;
+  /** @type {number} Write cursor -- bytes before this offset are valid buffered data. */
+  #end = 0;
+
+  /**
+   * Feed newly-read bytes in and pull out every complete chunk now
+   * available. Any trailing partial chunk stays buffered for the next
+   * `feed()` call.
+   *
+   * @param {Uint8Array} bytes
+   * @returns {Array<{nonce: Uint8Array, ciphertext: Uint8Array}>}
+   */
+  feed(bytes) {
+    if (bytes && bytes.length > 0) {
+      this.#append(bytes);
+    }
+    const chunks = [];
+    for (;;) {
+      const chunk = this.#tryParseOne();
+      if (chunk === null) break;
+      chunks.push(chunk);
+    }
+    // Once fully drained, reset cursors so the buffer doesn't retain a
+    // large-but-empty backing array indefinitely.
+    if (this.#start === this.#end) {
+      this.#start = 0;
+      this.#end = 0;
+    }
+    return chunks;
+  }
+
+  /**
+   * Call at clean stream EOF. Throws `StreamTornChunkError` if partial
+   * chunk bytes are still buffered (a truncated stream); otherwise a
+   * no-op.
+   */
+  finish() {
+    const remaining = this.#end - this.#start;
+    if (remaining > 0) {
+      throw new StreamTornChunkError(
+        `stream-frame: stream ended with ${remaining} torn (incomplete) chunk bytes buffered`
+      );
+    }
+  }
+
+  /** @private */
+  #append(bytes) {
+    const liveLength = this.#end - this.#start;
+    const needed = liveLength + bytes.length;
+    if (needed > this.#buf.length - this.#start) {
+      // Grow (and compact away already-consumed prefix bytes) with
+      // amortized doubling, so repeated small feed() calls stay linear
+      // overall rather than re-copying the whole live region every time.
+      const newCapacity = Math.max(needed, this.#buf.length * 2, 4096);
+      const newBuf = new Uint8Array(newCapacity);
+      newBuf.set(this.#buf.subarray(this.#start, this.#end), 0);
+      this.#buf = newBuf;
+      this.#end = liveLength;
+      this.#start = 0;
+    }
+    this.#buf.set(bytes, this.#end);
+    this.#end += bytes.length;
+  }
+
+  /** @private */
+  #tryParseOne() {
+    const available = this.#end - this.#start;
+    if (available < LENGTH_PREFIX_BYTES + NONCE_BYTES) return null;
+    const headerView = new DataView(this.#buf.buffer, this.#buf.byteOffset + this.#start, LENGTH_PREFIX_BYTES);
+    const n = headerView.getUint32(0, false);
+    if (n > MAX_WIRE_CIPHERTEXT_BYTES) {
+      throw new StreamTornChunkError(
+        `stream-frame: chunk length ${n} exceeds max ${MAX_WIRE_CIPHERTEXT_BYTES} -- corrupt or malicious framing`
+      );
+    }
+    const total = LENGTH_PREFIX_BYTES + NONCE_BYTES + n;
+    if (available < total) return null; // wait for more bytes
+    const nonceStart = this.#start + LENGTH_PREFIX_BYTES;
+    const ciphertextStart = nonceStart + NONCE_BYTES;
+    const nonce = this.#buf.slice(nonceStart, ciphertextStart);
+    const ciphertext = this.#buf.slice(ciphertextStart, this.#start + total);
+    this.#start += total;
+    return { nonce, ciphertext };
+  }
+}
+
+// ── Write coalescing ─────────────────────────────────────────────────
+//
+// Purely local, sender-side batching of small consecutive write() calls
+// into one sealed chunk -- NOT a wire protocol change (the receiver has
+// no idea how many writes got merged, see wsh #22's design-doc update).
+// Smart defaults derive from session `type` (already known at
+// `openSession()` time); callers can override via `enableE2E(key, {
+// coalesce })` or fully disable via `coalesce: false`.
+
+/**
+ * Default coalescing profiles by session kind.
+ *  - `pty` (interactive): latency-first -- flush on a short timer or a
+ *    small byte threshold, whichever fires first. This isn't "batching
+ *    keystrokes"; it mainly catches writes issued in the same event-loop
+ *    tick (multi-byte UTF-8, escape sequences, paste bursts) -- a single
+ *    keystroke still goes out almost immediately.
+ *  - `exec` (bulk): throughput-first -- longer timer and the full 16 KiB
+ *    soft target from the chunk-size design above.
+ * @type {Record<'pty'|'exec', {maxBytes: number, maxDelayMs: number}>}
+ */
+export const DEFAULT_COALESCE_PROFILES = Object.freeze({
+  pty: Object.freeze({ maxBytes: 4 * 1024, maxDelayMs: 6 }),
+  exec: Object.freeze({ maxBytes: CHUNK_SOFT_TARGET_BYTES, maxDelayMs: 30 }),
+});
+
+/**
+ * Resolve the effective coalescing config for a session.
+ *
+ * @param {'pty'|'exec'} kind
+ * @param {false|{maxBytes?: number, maxDelayMs?: number}|undefined} override
+ * @returns {{maxBytes: number, maxDelayMs: number}|null} `null` means "coalescing disabled -- seal every write immediately"
+ */
+export function resolveCoalesceOptions(kind, override) {
+  if (override === false) return null;
+  const base = DEFAULT_COALESCE_PROFILES[kind] || DEFAULT_COALESCE_PROFILES.exec;
+  if (override && typeof override === 'object') {
+    const maxBytes = Number.isFinite(override.maxBytes) && override.maxBytes > 0 ? override.maxBytes : base.maxBytes;
+    const maxDelayMs = Number.isFinite(override.maxDelayMs) && override.maxDelayMs >= 0 ? override.maxDelayMs : base.maxDelayMs;
+    return { maxBytes, maxDelayMs };
+  }
+  return { ...base };
+}
+
+/**
+ * Batches consecutive `write()` calls and flushes them as one chunk once
+ * `maxBytes` is buffered or `maxDelayMs` has elapsed since the first
+ * buffered byte of the current batch, whichever comes first.
+ *
+ * `write()` resolves once bytes are queued, not once they're actually
+ * flushed -- coalescing is local batching, so "queued" is the caller-
+ * visible unit of success (matching wsh #22's resolved design). Flush
+ * errors surface on the promise returned by the *next* `write()`/
+ * `flush()` call that observes the same underlying flush chain.
+ */
+export class WriteCoalescer {
+  #maxBytes;
+  #maxDelayMs;
+  #onFlush;
+  #pending = [];
+  #pendingLength = 0;
+  #timer = null;
+  #chain = Promise.resolve();
+
+  /**
+   * @param {{maxBytes: number, maxDelayMs: number}} options
+   * @param {function(Uint8Array): Promise<void>} onFlush - called with the merged buffered bytes
+   */
+  constructor({ maxBytes, maxDelayMs }, onFlush) {
+    if (!(maxBytes > 0)) {
+      throw new Error('stream-frame: WriteCoalescer requires a positive maxBytes');
+    }
+    if (!(maxDelayMs >= 0)) {
+      throw new Error('stream-frame: WriteCoalescer requires a non-negative maxDelayMs');
+    }
+    if (typeof onFlush !== 'function') {
+      throw new Error('stream-frame: WriteCoalescer requires an onFlush callback');
+    }
+    this.#maxBytes = maxBytes;
+    this.#maxDelayMs = maxDelayMs;
+    this.#onFlush = onFlush;
+  }
+
+  /**
+   * Buffer bytes for later coalesced sealing.
+   * @param {Uint8Array} bytes
+   * @returns {Promise<void>}
+   */
+  write(bytes) {
+    this.#pending.push(bytes);
+    this.#pendingLength += bytes.length;
+    if (this.#pendingLength >= this.#maxBytes) {
+      return this.flush();
+    }
+    if (this.#timer === null) {
+      this.#timer = setTimeout(() => {
+        this.#timer = null;
+        this.flush().catch(() => {
+          // Errors are observed via #chain by the next write()/flush()
+          // caller; swallow here so an unobserved timer-driven flush
+          // doesn't produce an unhandled rejection.
+        });
+      }, this.#maxDelayMs);
+      if (typeof this.#timer.unref === 'function') this.#timer.unref();
+    }
+    return this.#chain;
+  }
+
+  /**
+   * Force-flush any currently-buffered bytes immediately (used on
+   * session close and by the byte/timer thresholds above).
+   * @returns {Promise<void>}
+   */
+  flush() {
+    if (this.#timer !== null) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+    if (this.#pending.length === 0) {
+      return this.#chain;
+    }
+    const merged = concatBytes(this.#pending, this.#pendingLength);
+    this.#pending = [];
+    this.#pendingLength = 0;
+    this.#chain = this.#chain.then(() => this.#onFlush(merged));
+    return this.#chain;
+  }
+}
+
+/** @private */
+function concatBytes(parts, totalLength) {
+  if (parts.length === 1) return parts[0];
+  const out = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+// Re-exported for convenience so callers that only need stream-mode
+// sealing don't have to import from two modules.
+export { sealFrame };

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -842,3 +842,155 @@ describe('EncryptedFrame end-to-end integration', { skip: !hasEd25519 && 'Ed2551
     assert.equal(delivered, false);
   });
 });
+
+// ── Stream-mode chunk-framed EncryptedFrame end-to-end integration (wsh #22) ──
+//
+// Mirrors the virtual-mode integration tests above, but wires two real
+// WshSession instances in stream mode (`_bind()` with actual
+// ReadableStream/WritableStream pairs, like a real WebTransport data
+// stream) instead of `_activateVirtual()`. Confirms the whole PR-1 path
+// end to end: enableE2E() on a stream-mode session, write()'s chunk
+// sealing + framing (src/stream-frame.mjs's encodeChunk), and
+// _pumpDataStream()'s ChunkAccumulator + openFrame reassembly, all using
+// real production initiateE2E() key exchange.
+
+/**
+ * Builds a linked ReadableStream/WritableStream pair standing in for one
+ * direction of a raw WebTransport data stream: bytes written to
+ * `writable` are recorded in `wireLog` (standing in for what an
+ * eavesdropping relay/server would see) and then delivered to
+ * `readable`, optionally mutated by `mutate` first (to simulate an
+ * active tamperer).
+ */
+function makeLinkedStreamPair(wireLog, mutate) {
+  let controller;
+  const readable = new ReadableStream({
+    start(c) {
+      controller = c;
+    },
+  });
+  const writable = new WritableStream({
+    write(chunk) {
+      wireLog.push(chunk);
+      controller.enqueue(mutate ? mutate(chunk) : chunk);
+    },
+    close() {
+      controller.close();
+    },
+    abort(reason) {
+      controller.error(reason);
+    },
+  });
+  return { readable, writable };
+}
+
+describe('Stream-mode EncryptedFrame chunk framing end-to-end integration', { skip: !hasEd25519 && 'Ed25519 not available in this runtime' }, () => {
+  it('two real WshClient/WshSession pairs exchange chunk-framed sealed data over a raw stream that an eavesdropper cannot read', async () => {
+    const keyPairA = await auth.generateKeyPair(true);
+    const keyPairB = await auth.generateKeyPair(true);
+
+    const transportA = new E2ELinkedTransport('sess-e2e-stream');
+    const transportB = new E2ELinkedTransport('sess-e2e-stream');
+    transportA.link(transportB);
+    transportB.link(transportA);
+
+    const clientA = new clientMod.WshClient({ transportFactories: { ws: () => transportA } });
+    const clientB = new clientMod.WshClient({ transportFactories: { ws: () => transportB } });
+    await clientA.connect('ws://test.invalid', { username: 'alice', keyPair: keyPairA, transport: 'ws' });
+    await clientB.connect('ws://test.invalid', { username: 'bob', keyPair: keyPairB, transport: 'ws' });
+
+    const [resultA, resultB] = await Promise.all([
+      clientA.initiateE2E('sess-e2e-stream', 'X25519', 30_000),
+      clientB.initiateE2E('sess-e2e-stream', 'X25519', 30_000),
+    ]);
+
+    const sessionModule = await import('../src/session.mjs');
+    const { WshSession } = sessionModule;
+
+    const dummyTransport = { sendControl: async () => {} };
+    // 'exec' kind, matching the design's revised PR-3 plan to switch
+    // exec-type sessions to stream-mode data planes.
+    const sessionA = new WshSession(dummyTransport, 1, {}, 'exec', { dataMode: 'stream', sessionId: 'sess-e2e-stream' });
+    const sessionB = new WshSession(dummyTransport, 1, {}, 'exec', { dataMode: 'stream', sessionId: 'sess-e2e-stream' });
+
+    const wireLog = [];
+    const pipeAtoB = makeLinkedStreamPair(wireLog);
+    // sessionA never receives; sessionB never sends -- only the A -> B
+    // direction is exercised here, so the other halves are unused stubs.
+    sessionA._bind(new ReadableStream(), pipeAtoB.writable);
+    sessionB._bind(pipeAtoB.readable, new WritableStream());
+
+    // coalesce: false so this single write() seals and sends immediately
+    // (no timer/threshold to wait out in the test).
+    sessionA.enableE2E(resultA.sharedSecret, { role: 'initiator', coalesce: false });
+    sessionB.enableE2E(resultB.sharedSecret, { role: 'responder', coalesce: false });
+
+    const plaintext = 'this is a secret message sent over the raw chunk-framed stream';
+    const received = new Promise((resolve) => {
+      sessionB.onData = (data) => resolve(new TextDecoder().decode(data));
+    });
+
+    await sessionA.write(plaintext);
+    const receivedText = await received;
+
+    assert.equal(receivedText, plaintext);
+
+    // The eavesdropper must never see the plaintext, or any substring of
+    // it, anywhere in the raw bytes that crossed the "wire".
+    assert.equal(wireLog.length, 1);
+    const wireBytes = Buffer.concat(wireLog.map((chunk) => Buffer.from(chunk))).toString('latin1');
+    assert.equal(wireBytes.includes(plaintext), false);
+  });
+
+  it('a tampered chunk on the raw stream is not delivered as corrupted plaintext', async () => {
+    const keyPairA = await auth.generateKeyPair(true);
+    const keyPairB = await auth.generateKeyPair(true);
+
+    const transportA = new E2ELinkedTransport('sess-e2e-stream-tamper');
+    const transportB = new E2ELinkedTransport('sess-e2e-stream-tamper');
+    transportA.link(transportB);
+    transportB.link(transportA);
+
+    const clientA = new clientMod.WshClient({ transportFactories: { ws: () => transportA } });
+    const clientB = new clientMod.WshClient({ transportFactories: { ws: () => transportB } });
+    await clientA.connect('ws://test.invalid', { username: 'alice', keyPair: keyPairA, transport: 'ws' });
+    await clientB.connect('ws://test.invalid', { username: 'bob', keyPair: keyPairB, transport: 'ws' });
+
+    const [resultA, resultB] = await Promise.all([
+      clientA.initiateE2E('sess-e2e-stream-tamper', 'X25519', 30_000),
+      clientB.initiateE2E('sess-e2e-stream-tamper', 'X25519', 30_000),
+    ]);
+
+    const sessionModule = await import('../src/session.mjs');
+    const { WshSession } = sessionModule;
+    const dummyTransport = { sendControl: async () => {} };
+    const sessionA = new WshSession(dummyTransport, 1, {}, 'exec', { dataMode: 'stream', sessionId: 'sess-e2e-stream-tamper' });
+    const sessionB = new WshSession(dummyTransport, 1, {}, 'exec', { dataMode: 'stream', sessionId: 'sess-e2e-stream-tamper' });
+
+    const wireLog = [];
+    // Flip a byte inside the ciphertext region of the wire-format chunk
+    // ([4-byte len][12-byte nonce][ciphertext+tag]), simulating an
+    // active tamperer on the raw stream.
+    const pipeAtoB = makeLinkedStreamPair(wireLog, (chunk) => {
+      const tampered = chunk.slice();
+      tampered[4 + 12] ^= 0xff;
+      return tampered;
+    });
+    sessionA._bind(new ReadableStream(), pipeAtoB.writable);
+    sessionB._bind(pipeAtoB.readable, new WritableStream());
+
+    sessionA.enableE2E(resultA.sharedSecret, { role: 'initiator', coalesce: false });
+    sessionB.enableE2E(resultB.sharedSecret, { role: 'responder', coalesce: false });
+
+    let delivered = false;
+    sessionB.onData = () => {
+      delivered = true;
+    };
+
+    await sessionA.write('will be tampered with on the raw stream');
+    // Give the async openFrame()/pump loop a turn to run.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.equal(delivered, false);
+  });
+});

--- a/test/stream-frame.test.mjs
+++ b/test/stream-frame.test.mjs
@@ -1,0 +1,231 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { sealFrame, openFrame, ROLE_TAGS } from '../src/e2e-frame.mjs';
+import {
+  ChunkAccumulator, encodeChunk, StreamTornChunkError,
+  DEFAULT_COALESCE_PROFILES, resolveCoalesceOptions, WriteCoalescer,
+} from '../src/stream-frame.mjs';
+
+const hasWebCrypto = typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined';
+
+async function makeKey() {
+  const raw = crypto.getRandomValues(new Uint8Array(32));
+  return crypto.subtle.importKey('raw', raw, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']);
+}
+
+async function sealChunk(key, sessionId, counter, text) {
+  const plaintext = new TextEncoder().encode(text);
+  const { nonce, ciphertext } = await sealFrame(key, sessionId, ROLE_TAGS.initiator, counter, plaintext);
+  return { nonce, ciphertext, wire: encodeChunk(nonce, ciphertext), plaintext };
+}
+
+describe('stream-frame: ChunkAccumulator + encodeChunk', { skip: !hasWebCrypto && 'WebCrypto not available in this runtime' }, () => {
+  it('round-trips a single chunk fed in one call', async () => {
+    const key = await makeKey();
+    const { wire, plaintext } = await sealChunk(key, 'sess-1', 0, 'hello stream world');
+
+    const acc = new ChunkAccumulator();
+    const chunks = acc.feed(wire);
+    assert.equal(chunks.length, 1);
+
+    const opened = await openFrame(key, 'sess-1', 0, chunks[0]);
+    assert.deepEqual([...opened], [...plaintext]);
+    assert.doesNotThrow(() => acc.finish());
+  });
+
+  it('tamper detection: a flipped ciphertext byte fails openFrame after reassembly', async () => {
+    const key = await makeKey();
+    const { wire } = await sealChunk(key, 'sess-2', 0, 'do not tamper with this chunk');
+
+    // Flip a byte inside the ciphertext region (after the 4-byte length
+    // prefix + 12-byte nonce).
+    const tampered = wire.slice();
+    tampered[4 + 12] ^= 0xff;
+
+    const acc = new ChunkAccumulator();
+    const [chunk] = acc.feed(tampered);
+    assert.ok(chunk);
+
+    await assert.rejects(() => openFrame(key, 'sess-2', 0, chunk));
+  });
+
+  it('finish() throws StreamTornChunkError for a torn chunk left at EOF', () => {
+    const acc = new ChunkAccumulator();
+    // Feed a length prefix claiming more bytes than actually follow.
+    const partial = new Uint8Array(4 + 12 + 5);
+    new DataView(partial.buffer).setUint32(0, 100, false); // claims 100 ciphertext bytes, only 5 present
+    const chunks = acc.feed(partial);
+    assert.equal(chunks.length, 0);
+    assert.throws(() => acc.finish(), StreamTornChunkError);
+  });
+
+  it('finish() is a clean no-op when the buffer is empty (nothing torn)', () => {
+    const acc = new ChunkAccumulator();
+    assert.doesNotThrow(() => acc.finish());
+  });
+
+  it('multiple complete chunks arriving in a single read() are all extracted, in order', async () => {
+    const key = await makeKey();
+    const a = await sealChunk(key, 'sess-3', 0, 'first chunk');
+    const b = await sealChunk(key, 'sess-3', 1, 'second chunk');
+    const c = await sealChunk(key, 'sess-3', 2, 'third chunk');
+
+    const combined = new Uint8Array(a.wire.length + b.wire.length + c.wire.length);
+    combined.set(a.wire, 0);
+    combined.set(b.wire, a.wire.length);
+    combined.set(c.wire, a.wire.length + b.wire.length);
+
+    const acc = new ChunkAccumulator();
+    const chunks = acc.feed(combined);
+    assert.equal(chunks.length, 3);
+
+    const opened = await Promise.all(chunks.map((chunk, i) => openFrame(key, 'sess-3', i, chunk)));
+    assert.equal(new TextDecoder().decode(opened[0]), 'first chunk');
+    assert.equal(new TextDecoder().decode(opened[1]), 'second chunk');
+    assert.equal(new TextDecoder().decode(opened[2]), 'third chunk');
+    assert.doesNotThrow(() => acc.finish());
+  });
+
+  it('one chunk split across two feed() calls is only delivered once complete', async () => {
+    const key = await makeKey();
+    const { wire, plaintext } = await sealChunk(key, 'sess-4', 0, 'a chunk delivered in two pieces');
+
+    const splitPoint = Math.floor(wire.length / 2);
+    const first = wire.slice(0, splitPoint);
+    const second = wire.slice(splitPoint);
+
+    const acc = new ChunkAccumulator();
+    const chunksAfterFirst = acc.feed(first);
+    assert.equal(chunksAfterFirst.length, 0, 'no chunk should be available from a partial feed');
+
+    const chunksAfterSecond = acc.feed(second);
+    assert.equal(chunksAfterSecond.length, 1);
+
+    const opened = await openFrame(key, 'sess-4', 0, chunksAfterSecond[0]);
+    assert.deepEqual([...opened], [...plaintext]);
+    assert.doesNotThrow(() => acc.finish());
+  });
+
+  it('a length header split across two feed() calls is handled once the header completes', async () => {
+    const key = await makeKey();
+    const { wire, plaintext } = await sealChunk(key, 'sess-5', 0, 'short');
+
+    // Split in the middle of the 4-byte length prefix itself.
+    const first = wire.slice(0, 2);
+    const second = wire.slice(2);
+
+    const acc = new ChunkAccumulator();
+    assert.equal(acc.feed(first).length, 0);
+    const chunks = acc.feed(second);
+    assert.equal(chunks.length, 1);
+
+    const opened = await openFrame(key, 'sess-5', 0, chunks[0]);
+    assert.deepEqual([...opened], [...plaintext]);
+  });
+
+  it('many tiny feed() calls (byte-at-a-time) still reassemble correctly', async () => {
+    const key = await makeKey();
+    const { wire, plaintext } = await sealChunk(key, 'sess-6', 0, 'trickled in one byte at a time');
+
+    const acc = new ChunkAccumulator();
+    let chunks = [];
+    for (const byte of wire) {
+      chunks = chunks.concat(acc.feed(Uint8Array.of(byte)));
+    }
+    assert.equal(chunks.length, 1);
+    const opened = await openFrame(key, 'sess-6', 0, chunks[0]);
+    assert.deepEqual([...opened], [...plaintext]);
+  });
+});
+
+describe('stream-frame: write coalescing', () => {
+  it('the pty and exec default profiles differ (latency-first vs throughput-first)', () => {
+    const pty = DEFAULT_COALESCE_PROFILES.pty;
+    const exec = DEFAULT_COALESCE_PROFILES.exec;
+    assert.ok(pty.maxDelayMs < exec.maxDelayMs, 'pty timer should be shorter than exec timer');
+    assert.ok(pty.maxBytes < exec.maxBytes, 'pty byte threshold should be smaller than exec');
+  });
+
+  it('resolveCoalesceOptions() picks the profile by session kind', () => {
+    assert.deepEqual(resolveCoalesceOptions('pty', undefined), DEFAULT_COALESCE_PROFILES.pty);
+    assert.deepEqual(resolveCoalesceOptions('exec', undefined), DEFAULT_COALESCE_PROFILES.exec);
+  });
+
+  it('resolveCoalesceOptions(kind, false) disables coalescing', () => {
+    assert.equal(resolveCoalesceOptions('pty', false), null);
+    assert.equal(resolveCoalesceOptions('exec', false), null);
+  });
+
+  it('resolveCoalesceOptions() honors an explicit override, filling in defaults for omitted fields', () => {
+    const resolved = resolveCoalesceOptions('pty', { maxBytes: 1234 });
+    assert.equal(resolved.maxBytes, 1234);
+    assert.equal(resolved.maxDelayMs, DEFAULT_COALESCE_PROFILES.pty.maxDelayMs);
+  });
+
+  it('WriteCoalescer flushes once maxBytes is reached, merging buffered writes into one flush call', async () => {
+    const flushed = [];
+    const coalescer = new WriteCoalescer({ maxBytes: 10, maxDelayMs: 10_000 }, async (bytes) => {
+      flushed.push(bytes);
+    });
+
+    await coalescer.write(new Uint8Array([1, 2, 3]));
+    await coalescer.write(new Uint8Array([4, 5, 6]));
+    // Still under 10 bytes buffered -- no flush yet.
+    assert.equal(flushed.length, 0);
+
+    await coalescer.write(new Uint8Array([7, 8, 9, 10]));
+    // 10 bytes buffered >= maxBytes -- flush should have fired, merging all three writes.
+    assert.equal(flushed.length, 1);
+    assert.deepEqual([...flushed[0]], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it('WriteCoalescer flushes on the timer even under the byte threshold', async () => {
+    const flushed = [];
+    const coalescer = new WriteCoalescer({ maxBytes: 1_000_000, maxDelayMs: 15 }, async (bytes) => {
+      flushed.push(bytes);
+    });
+
+    await coalescer.write(new Uint8Array([42]));
+    assert.equal(flushed.length, 0);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(flushed.length, 1);
+    assert.deepEqual([...flushed[0]], [42]);
+  });
+
+  it('WriteCoalescer.flush() force-flushes immediately regardless of thresholds', async () => {
+    const flushed = [];
+    const coalescer = new WriteCoalescer({ maxBytes: 1_000_000, maxDelayMs: 1_000_000 }, async (bytes) => {
+      flushed.push(bytes);
+    });
+
+    await coalescer.write(new Uint8Array([9, 9]));
+    assert.equal(flushed.length, 0);
+    await coalescer.flush();
+    assert.equal(flushed.length, 1);
+  });
+
+  it('a pty-profile coalescer flushes noticeably sooner than an exec-profile one for the same small write', async () => {
+    const ptyFlushedAt = { time: null };
+    const execFlushedAt = { time: null };
+    const start = Date.now();
+
+    const ptyCoalescer = new WriteCoalescer(DEFAULT_COALESCE_PROFILES.pty, async () => {
+      ptyFlushedAt.time = Date.now() - start;
+    });
+    const execCoalescer = new WriteCoalescer(DEFAULT_COALESCE_PROFILES.exec, async () => {
+      execFlushedAt.time = Date.now() - start;
+    });
+
+    await ptyCoalescer.write(new Uint8Array([1]));
+    await execCoalescer.write(new Uint8Array([1]));
+
+    // Wait long enough for the pty timer to fire but well short of the
+    // exec timer.
+    await new Promise((resolve) => setTimeout(resolve, DEFAULT_COALESCE_PROFILES.pty.maxDelayMs + 15));
+    assert.notEqual(ptyFlushedAt.time, null, 'pty coalescer should have flushed by now');
+    assert.equal(execFlushedAt.time, null, 'exec coalescer should not have flushed yet');
+
+    await execCoalescer.flush();
+  });
+});


### PR DESCRIPTION
## Summary

PR 1 of 3 sealing wsh's stream-mode sessions with AES-256-GCM, per the design in #22 (and its follow-up comment resolving write-coalescing and adding a live caller for exec-type sessions in PR 3).

- **`src/stream-frame.mjs` (new)**: `ChunkAccumulator` reassembles inline `[4-byte BE length][12-byte nonce][ciphertext+16-byte tag]` chunks out of an arbitrarily-fragmented raw byte stream, using a cursor-based internal buffer (amortized-doubling growth, no repeated whole-buffer `slice()`) to avoid quadratic behavior under many small reads. `encodeChunk()` builds chunks for the write side. `StreamTornChunkError` (partial chunk left at EOF) and `StreamAuthenticationError` (complete chunk, failed AEAD auth) are distinct error types per the design's "no skip-and-continue" philosophy — no partial-chunk plaintext is ever released.
- **Write coalescing**, per the design's resolved decision: purely local, sender-side batching (not a wire protocol change). `WriteCoalescer` batches writes on a byte-or-timer threshold with smart defaults derived from session `kind` (`pty`: ~4KiB/6ms, latency-first; `exec`: ~16KiB/30ms, throughput-first). Overridable via `enableE2E(key, { coalesce: { maxBytes, maxDelayMs } })`, or `coalesce: false` to seal every write immediately.
- **`src/session.mjs`**: `enableE2E()` no longer rejects stream-mode sessions — it now branches internally on `dataMode`, same pattern as `write()` already used. Stream-mode `write()` seals via `sealFrame` + `encodeChunk`, routed through the coalescer (or immediately if disabled). `_pumpDataStream()` feeds incoming bytes through `ChunkAccumulator` and opens each complete chunk via `openFrame` before handing plaintext to `onData`. `close()` flushes any buffered coalesced bytes before closing the stdin writer; clean EOF calls `accumulator.finish()` to catch torn chunks.
- **`spec/wsh-v1.yaml`**: notes stream-mode E2E uses inline chunk framing, not a new CBOR message type — invisible to the control-message spec (`EncryptedFrame` stays virtual-mode-only). Regenerated `spec/wsh-v1.md` — no diff, since that doc doesn't currently render the experimental `e2e` section (pre-existing gap, out of scope here).
- Reuses `sealFrame`/`openFrame`/`buildNonce`/`ROLE_TAGS` from `e2e-frame.mjs` **unchanged** — this is a framing layer on top, not a new crypto module.

## Tests

- `test/stream-frame.test.mjs` (new, 16 tests): round-trip, tamper detection, torn-chunk detection at EOF, multi-chunk-in-one-read, chunk split across two reads, length-header split across two reads, byte-at-a-time feed, and coalescing behavior (pty vs exec profile timing/threshold, explicit override, `coalesce: false`).
- `test/client.test.mjs`: two new integration tests mirroring the existing virtual-mode `EncryptedFrame` end-to-end tests, but wiring two real `WshClient`/`WshSession` pairs in stream mode via `_bind()` with real `ReadableStream`/`WritableStream` pairs (standing in for a real WebTransport data stream) — confirms data round-trips through real production `initiateE2E()` key exchange and that a tampered chunk is dropped, not delivered as corrupted plaintext.

**421 → 439 tests, all green** (`npm test`).

## Sequencing

Per the issue: PR 1 (this PR, wsh JS chunk framing) → PR 2 (clawser Rust mirror + JS↔Rust interop test) → PR 3 (clawser: switch `exec`-type sessions to `data_mode: 'stream'` in both servers + real end-to-end verification).

## Test plan

- [x] `npm test` — 439/439 passing (up from 421 baseline)
- [x] New unit tests cover round-trip, tamper detection, torn-chunk detection, chunk/header splitting across reads, and coalescing profile behavior
- [x] New integration tests cover the full real-key-exchange → stream-mode `enableE2E()` → `write()`/`_pumpDataStream()` path end to end