### PR TITLE
Fix premature session close on data-stream EOF race (#24)

### DIFF
--- a/src/session.mjs
+++ b/src/session.mjs
@@ -20,6 +20,17 @@ const STATE_OPENING = 'opening';
 const STATE_ACTIVE  = 'active';
 const STATE_CLOSED  = 'closed';
 
+/**
+ * Stream-mode data and control streams are independently-multiplexed
+ * transport streams (QUIC/QMux) with no guaranteed relative delivery
+ * order (wsh #24). When the data stream reaches EOF, the server-sent
+ * `CLOSE` control message -- not the data-stream FIN -- is the
+ * authoritative close signal, so `_pumpDataStream()` waits up to this
+ * long for `CLOSE` to arrive before falling back to closing on data-EOF
+ * alone (a safety net for servers that never send `CLOSE`).
+ */
+const DATA_EOF_CLOSE_GRACE_MS = 300;
+
 // ── Text encoding ─────────────────────────────────────────────────────
 
 const textEncoder = new TextEncoder();
@@ -132,6 +143,16 @@ export class WshSession {
 
   /** @type {number|null} Exit code received from the server. */
   #exitCode = null;
+
+  /**
+   * Pending fallback timer scheduled when the data stream hits EOF
+   * before a `CLOSE` control message has arrived (wsh #24). Cleared
+   * as soon as `CLOSE` arrives (or the session is otherwise closed) so
+   * a prompt `CLOSE` short-circuits the wait instead of idling out the
+   * full grace period.
+   * @type {ReturnType<typeof setTimeout>|null}
+   */
+  #closeGraceTimer = null;
 
   // ── Callbacks ───────────────────────────────────────────────────────
 
@@ -580,6 +601,7 @@ export class WshSession {
     // Optimistically mark closed so no further writes are accepted.
     this.#state = STATE_CLOSED;
     this.#abort.abort();
+    this.#clearCloseGraceTimer();
 
     // Send CLOSE to the server (best-effort).
     try {
@@ -697,7 +719,11 @@ export class WshSession {
       }
 
       case MSG.CLOSE: {
-        // Server-initiated close.
+        // Server-initiated close. This is the authoritative close signal
+        // for stream-mode sessions (wsh #24) -- it always short-circuits
+        // any pending data-EOF grace timer, regardless of which arrived
+        // first.
+        this.#clearCloseGraceTimer();
         if (this.#state !== STATE_CLOSED) {
           this.#state = STATE_CLOSED;
           this.#abort.abort();
@@ -879,16 +905,42 @@ export class WshSession {
       reader.releaseLock();
     }
 
-    // If the data stream ended but we haven't received a CLOSE message,
-    // transition to closed state.
-    if (this.#state !== STATE_CLOSED) {
-      this.#state = STATE_CLOSED;
-      this.#releaseStreams();
-      this.#emitClose();
+    // The data stream ended, but its FIN carries no ordering guarantee
+    // relative to the control stream (wsh #24): a server that closes the
+    // data stream and sends EXIT/CLOSE around the same time can have
+    // this EOF arrive before those control messages. Closing the session
+    // here unconditionally would resolve onClose without onExit ever
+    // having fired. Instead, give the (expected) CLOSE control message a
+    // bounded grace period to arrive -- its handler clears this timer and
+    // performs the real transition -- and only self-close on timeout as a
+    // fallback for servers that never send CLOSE after ending the data
+    // stream.
+    if (this.#state !== STATE_CLOSED && this.#closeGraceTimer === null) {
+      this.#closeGraceTimer = setTimeout(() => {
+        this.#closeGraceTimer = null;
+        if (this.#state !== STATE_CLOSED) {
+          this.#state = STATE_CLOSED;
+          this.#releaseStreams();
+          this.#emitClose();
+        }
+      }, DATA_EOF_CLOSE_GRACE_MS);
+      this.#closeGraceTimer?.unref?.();
     }
   }
 
   // ── Private helpers ─────────────────────────────────────────────────
+
+  /**
+   * Cancel any pending data-EOF close-grace timer (wsh #24). Safe to call
+   * whether or not a timer is currently scheduled.
+   * @private
+   */
+  #clearCloseGraceTimer() {
+    if (this.#closeGraceTimer !== null) {
+      clearTimeout(this.#closeGraceTimer);
+      this.#closeGraceTimer = null;
+    }
+  }
 
   /**
    * Release stream resources without sending a CLOSE message.

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -994,3 +994,143 @@ describe('Stream-mode EncryptedFrame chunk framing end-to-end integration', { sk
     assert.equal(delivered, false);
   });
 });
+
+// ── Data-stream EOF vs EXIT/CLOSE control-message race (wsh #24) ──────
+//
+// Stream-mode sessions carry data and control on two independently-
+// multiplexed transport streams with no guaranteed relative delivery
+// order. A server that ends the data stream and sends EXIT+CLOSE around
+// the same time (as on process exit) can have the data-stream FIN reach
+// the client first. Before the wsh #24 fix, _pumpDataStream() treated
+// that FIN alone as sufficient to close the session, so callers waiting
+// on onClose could resolve before onExit ever fired -- silently losing
+// the exit code. These tests deliberately control the delivery order
+// (something a naive "everything arrives in the expected order" test
+// would never exercise) via the real dispatch entry points --
+// `_bind()`'s pump loop for the data stream and `_handleControlMessage()`
+// for control messages -- rather than poking at session internals.
+
+/**
+ * A stream-mode WshSession bound to a controllable ReadableStream, so
+ * the test can decide exactly when the data stream reaches EOF
+ * independently of when control messages are delivered via
+ * `_handleControlMessage()`.
+ */
+async function makeControllableStreamSession() {
+  const sessionModule = await import('../src/session.mjs');
+  const { WshSession } = sessionModule;
+  const dummyTransport = { sendControl: async () => {} };
+
+  let controller;
+  const readable = new ReadableStream({
+    start(c) {
+      controller = c;
+    },
+  });
+  const session = new WshSession(dummyTransport, 1, {}, 'exec', { dataMode: 'stream' });
+  session._bind(readable, new WritableStream());
+
+  return { session, closeDataStream: () => controller.close() };
+}
+
+describe('WshSession data-stream EOF vs EXIT/CLOSE control-message race (wsh #24)', () => {
+  it('data-stream EOF arriving before EXIT/CLOSE does not lose the exit code (adversarial ordering)', async () => {
+    const { session, closeDataStream } = await makeControllableStreamSession();
+
+    const events = [];
+    const closed = new Promise((resolve) => {
+      session.onClose = () => {
+        events.push('close');
+        resolve();
+      };
+    });
+    session.onExit = (code) => {
+      events.push(`exit:${code}`);
+    };
+
+    // Unlucky delivery order: the data stream's FIN reaches the client
+    // first...
+    closeDataStream();
+    // ...give the pump loop a turn to observe EOF and schedule its grace
+    // timer before the control messages "arrive" (simulating them
+    // actually being in flight on a separate stream at data-EOF time).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    // ...and only afterwards do EXIT and CLOSE land, via the real
+    // control-message dispatch path.
+    session._handleControlMessage({ type: MSG.EXIT, code: 42 });
+    session._handleControlMessage({ type: MSG.CLOSE });
+
+    await closed;
+
+    assert.deepEqual(events, ['exit:42', 'close']);
+    assert.equal(session.exitCode, 42);
+  });
+
+  it('CLOSE arriving promptly short-circuits the grace period instead of waiting it out', async () => {
+    const { session, closeDataStream } = await makeControllableStreamSession();
+
+    const closed = new Promise((resolve) => {
+      session.onClose = resolve;
+    });
+
+    closeDataStream();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const start = Date.now();
+    session._handleControlMessage({ type: MSG.EXIT, code: 0 });
+    session._handleControlMessage({ type: MSG.CLOSE });
+    await closed;
+    const elapsed = Date.now() - start;
+
+    // The session-level DATA_EOF_CLOSE_GRACE_MS fallback is 300ms; a
+    // prompt CLOSE must resolve onClose well before that, not idle out
+    // the timer.
+    assert.ok(elapsed < 150, `expected CLOSE to short-circuit the wait, took ${elapsed}ms`);
+  });
+
+  it('control messages arriving before data-stream EOF close normally (non-adversarial ordering)', async () => {
+    const { session, closeDataStream } = await makeControllableStreamSession();
+
+    const events = [];
+    const closed = new Promise((resolve) => {
+      session.onClose = () => {
+        events.push('close');
+        resolve();
+      };
+    });
+    session.onExit = (code) => {
+      events.push(`exit:${code}`);
+    };
+
+    session._handleControlMessage({ type: MSG.EXIT, code: 7 });
+    session._handleControlMessage({ type: MSG.CLOSE });
+    closeDataStream();
+
+    await closed;
+
+    assert.deepEqual(events, ['exit:7', 'close']);
+    assert.equal(session.state, 'closed');
+  });
+
+  it('falls back to closing after the grace period if CLOSE never arrives (no hang)', async () => {
+    const { session, closeDataStream } = await makeControllableStreamSession();
+
+    const closed = new Promise((resolve) => {
+      session.onClose = resolve;
+    });
+
+    const start = Date.now();
+    closeDataStream();
+    // Deliberately never send CLOSE.
+    await closed;
+    const elapsed = Date.now() - start;
+
+    assert.equal(session.state, 'closed');
+    // Must have waited out (approximately) the grace period, not closed
+    // instantly on data-EOF alone...
+    assert.ok(elapsed >= 250, `expected the grace-period fallback (~300ms), closed after only ${elapsed}ms`);
+    // ...but also must not hang indefinitely.
+    assert.ok(elapsed < 2000, `grace-period fallback took far too long: ${elapsed}ms`);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #24: `WshSession._pumpDataStream()` treated the data stream reaching EOF as sufficient grounds to immediately transition the session to `closed` and fire `onClose`, regardless of whether the `EXIT`/`CLOSE` control messages had arrived yet.

For stream-mode sessions, the data stream and control stream are independently-multiplexed transport streams (QUIC/QMux) with **no guaranteed relative delivery order**. A server that closes the data stream and sends `EXIT`+`CLOSE` around the same time (e.g. on process exit) can have the data-stream FIN arrive first. When that happens, `onClose` resolves before `onExit` ever fires — silently losing the exit code.

## Fix

- Added `DATA_EOF_CLOSE_GRACE_MS` (300ms) module constant.
- On data-stream EOF, `_pumpDataStream()` no longer calls `#emitClose()` immediately. Instead it schedules a bounded grace-period timer as a fallback.
- The `MSG.CLOSE` handler (the authoritative close signal) now clears that timer as its first action, so a prompt `CLOSE` short-circuits the wait instead of idling out the grace period.
- `close()` (explicit local close) also clears the timer to avoid a stray callback firing after teardown.
- The timer is `unref()`'d where supported so it never keeps a Node process alive.
- `EXIT` itself needed no changes — it was never the problem; the fix ensures `onClose` can't resolve early and strand it.

## Test plan

- [x] `npm test` — 443/443 passing (up from the 439 baseline; +4 new tests), all green.
- [x] New regression tests in `test/client.test.mjs` under "WshSession data-stream EOF vs EXIT/CLOSE control-message race (wsh #24)":
  - Adversarial ordering: data-stream EOF fires before `EXIT`+`CLOSE` are delivered — asserts `onExit` still fires with the correct code before `onClose` resolves.
  - Prompt `CLOSE` short-circuits the grace period (resolves well under the 300ms fallback).
  - Non-adversarial ordering (control messages before data EOF) still closes correctly.
  - Fallback path: data EOF with `CLOSE` never sent — session still closes (no hang), only after waiting out the grace period.
- All four tests drive the real dispatch paths (`_bind()`'s pump loop and `_handleControlMessage()`), not direct internal state manipulation.