### PR TITLE
Pass WebTransport options through, close leaked sockets, and test the transport ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,17 +257,80 @@ The `spec/` directory contains the protocol definition:
 
 ## Browser Compatibility
 
-Requires a browser (or Node.js 24+) with:
+Requires a browser (or Node.js 24+) with `TextEncoder`/`TextDecoder`,
+`ReadableStream`/`WritableStream`, `WebSocket` (universal), and:
 
-- Web Crypto API with Ed25519 support
-- WebSocket (all browsers)
-- WebTransport (Chrome 97+, Edge 97+, Firefox 114+)
-- TextEncoder/TextDecoder
-- ReadableStream/WritableStream
+### WebCrypto Ed25519 -- the real floor
 
-Hybrid ML-KEM-768 key exchange prefers native WebCrypto ML-KEM (Node 24.7+,
-some browsers); elsewhere the optional `@noble/post-quantum` dependency is
-loaded dynamically.
+This is what actually gates the library, because pubkey auth is not
+optional to the protocol. Roughly: **Safari 17+, Chrome/Edge 137+,
+Firefox 130+, Node 20+**.
+
+There is deliberately **no pure-JS fallback**. A JS Ed25519 needs the
+private scalar as ordinary bytes, which would give up the property
+`WshKeyStore` is built around -- keys are non-extractable `CryptoKey`
+objects by default, so a compromised page can *use* a key but cannot
+exfiltrate it. Trading that away on exactly the oldest, least-patched
+engines is the wrong direction, and doing it silently would be worse.
+
+Ask before you commit to pubkey auth:
+
+```js
+import { isEd25519Supported } from '@johnhenry/wsh';
+
+if (await isEd25519Supported()) {
+  await client.connect(url, { username, keyPair });
+} else {
+  await client.connect(url, { username, password });
+}
+```
+
+`isEd25519Supported()` measures by generating a key rather than sniffing a
+version string, and memoizes. `generateKeyPair()` throws with an
+actionable message where support is missing, rather than passing the
+platform's "Unrecognized name" straight through.
+
+### WebTransport
+
+WebTransport is optional -- the transport ladder falls back to WebSocket.
+It matters if you want `serverCertificateHashes` (see [Pinning a
+Self-Signed Certificate](#pinning-a-self-signed-certificate)), which has
+no WebSocket equivalent.
+
+**Safari supports WebTransport, and more of it than Chromium does.**
+That is the opposite of the usual assumption, and the earlier version of
+this section propagated the assumption by listing only Chrome, Edge and
+Firefox. Measured on 2026-09-04, both engines on a `localhost` secure
+context:
+
+| | `WebTransport.prototype` members | Ed25519 | X25519 | ML-KEM-768 |
+|---|---|---|---|---|
+| WebKit -- Safari 26.5, iOS 26.5 simulator | **17** | OK | OK | fails (`TypeError`) |
+| Chromium 148, macOS | 10 | OK | OK | fails (`NotSupportedError`) |
+
+WebKit's extra seven are `congestionControl`, `reliability`, `draining`,
+`getStats`, `createSendGroup`, and the two
+`anticipatedConcurrentIncoming*Streams` hints; both engines have
+`datagrams`, both bidirectional and unidirectional stream creation, and
+`ready`/`closed`.
+
+Approximate first-support versions, which are *not* measured here: Chrome
+and Edge 97, Firefox 114, Safari 26. Below Safari 26, the ladder falls
+back to WebSocket.
+
+Both engines accept a `serverCertificateHashes` entry without a
+synchronous throw, but that is weak evidence on its own -- unknown WebIDL
+dictionary members are silently ignored, so acceptance does not prove the
+option is honoured. Confirming it needs a real HTTP/3 server presenting a
+matching short-lived certificate.
+
+### ML-KEM-768
+
+The hybrid post-quantum path prefers native WebCrypto ML-KEM (Node 24.7+).
+**No browser tested has it** -- it failed on both engines above -- so in a
+browser the optional `@noble/post-quantum` dependency is what actually
+runs, loaded dynamically by `src/mlkem.mjs`. Treat it as required, not
+optional, if you want the hybrid handshake on the web today.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Or via CDN:
 
 - **Ed25519 authentication** -- challenge-response via Web Crypto API with a transcript binding username and session id, SSH key format support
 - **Dual transport** -- WebTransport (native streams) and WebSocket (QMux-multiplexed streams) with identical API
+- **Self-signed certificate pinning** -- `serverCertificateHashes` on the WebTransport path, so page JavaScript can reach a server whose certificate no certificate authority signed
 - **CBOR encoding** -- compact binary wire format with length-prefixed framing
 - **Session management** -- open, attach, resume, detach, rename PTY/exec sessions, with session-scoped resume tokens and per-principal access grants
 - **Reverse mode** -- register as a peer (via a signed peer record) and accept incoming connections through a relay
@@ -127,6 +128,67 @@ await client.detach(session.sessionId);   // leave it running server-side
 await client.listRemoteSessions();        // sessions this key can see
 ```
 
+## Pinning a Self-Signed Certificate
+
+Both transports normally need a certificate a public certificate authority
+signed. On a LAN -- a phone talking to a desktop on `192.168.x.x`, a
+browser talking to a device on the same Wi-Fi -- there is no such
+certificate to be had, and a plaintext `ws://` from an `https://` page is
+blocked as mixed content.
+
+WebTransport is the one place in the web platform with an answer:
+`serverCertificateHashes` lets the page pin a specific certificate by
+SHA-256 digest, no certificate authority involved.
+
+```js
+// The digest can be raw bytes, base64, plain hex, or the colon-separated
+// hex `openssl x509 -fingerprint -sha256 -noout -in cert.pem` prints --
+// the whole `SHA256 Fingerprint=AB:CD:...` line is accepted as-is.
+await client.connect('https://192.168.1.20:4433/wsh', {
+  username: 'alice',
+  keyPair,
+  transport: 'wt',
+  webTransport: {
+    serverCertificateHashes: [
+      'SHA256 Fingerprint=A1:B2:C3:...',
+    ],
+  },
+});
+```
+
+`WebTransportTransport` also takes the same options directly, for use with
+`connectWithTransport()`:
+
+```js
+const transport = new WebTransportTransport({
+  serverCertificateHashes: [certDigestBytes],
+});
+```
+
+A malformed digest throws locally (`RangeError` for the wrong length,
+`TypeError` for an unrecognised shape) before any connection is
+attempted -- a wrong hash otherwise surfaces only as an opaque
+`WebTransportError` from `wt.ready`.
+
+The constraints are the platform's, not wsh's:
+
+- The URL must be `https:`; pinning is HTTP/3 only, with no HTTP/2 fallback.
+- The certificate must use an **ECDSA P-256** key and be valid for **at most
+  14 days**, so it has to be reissued on a schedule.
+- Connection pooling is disabled for a pinned connection.
+- Only `sha-256` is accepted as the algorithm.
+
+The option applies to the WebTransport rung of the transport ladder only.
+If the WebTransport attempt fails and the client falls back to WebSocket,
+that `wss:` connection is subject to the ordinary certificate-authority
+check again -- there is no WebSocket equivalent of certificate pinning.
+Pass `transport: 'wt'` if you would rather fail than fall back.
+
+Any other key in `webTransport` is forwarded to the `WebTransport`
+constructor verbatim (`congestionControl`, `allowPooling`,
+`requireUnreliable`, the `anticipatedConcurrentIncoming*Streams` hints),
+so options the platform gains later need no change here.
+
 ## API Overview
 
 ### Core Classes
@@ -136,7 +198,7 @@ await client.listRemoteSessions();        // sessions this key can see
 | `WshClient` | Full lifecycle client: connect, auth, sessions, reverse mode, MCP |
 | `WshSession` | Single PTY or exec channel with read/write/resize/signal |
 | `WshTransport` | Abstract transport base class |
-| `WebTransportTransport` | WebTransport implementation (native streams) |
+| `WebTransportTransport` | WebTransport implementation (native streams); takes `serverCertificateHashes` and other `WebTransport` options |
 | `WebSocketTransport` | WebSocket implementation (multiplexed virtual streams) |
 
 ### Utilities
@@ -152,6 +214,8 @@ await client.listRemoteSessions();        // sessions this key can see
 | `signChallenge()` | Build transcript + sign for auth handshake |
 | `signPeerRecord()` / `verifyPeerRecord()` | Sign / verify reverse-mode peer records |
 | `fingerprint()` | SHA-256 hex fingerprint of a public key |
+| `parseCertificateHash()` | Decode a certificate digest from hex / base64 / bytes |
+| `normalizeWebTransportOptions()` | Build a `WebTransportOptions` dictionary from loose input |
 
 ### Protocol
 

--- a/src/auth.mjs
+++ b/src/auth.mjs
@@ -5,15 +5,77 @@
 
 import { PROTOCOL_VERSION } from './messages.mjs';
 
+// ── Capability detection ──────────────────────────────────────────────
+
+/** @type {Promise<boolean>|null} Memoized: the answer cannot change at runtime. */
+let ed25519Support = null;
+
+/**
+ * Whether this runtime's WebCrypto implements Ed25519.
+ *
+ * There is deliberately no pure-JS fallback behind this. A JS
+ * implementation needs the private scalar as ordinary bytes, which would
+ * quietly give up the property `WshKeyStore` is built around -- keys are
+ * non-extractable `CryptoKey` objects by default, so a compromised page
+ * can use a key but cannot exfiltrate it. Trading that away on exactly
+ * the oldest, least-patched engines is the wrong direction, and doing it
+ * silently is worse. So wsh's floor is WebCrypto Ed25519, and this is how
+ * an application asks about it before committing to pubkey auth:
+ *
+ * ```js
+ * if (await isEd25519Supported()) {
+ *   await client.connect(url, { username, keyPair });
+ * } else {
+ *   await client.connect(url, { username, password });   // AUTH_METHOD.PASSWORD
+ * }
+ * ```
+ *
+ * Measured directly rather than sniffed from a version string: `'Ed25519'`
+ * is accepted as an algorithm name by some engines that then fail at
+ * `generateKey`, so nothing short of generating a key is conclusive.
+ *
+ * @returns {Promise<boolean>}
+ */
+export async function isEd25519Supported() {
+  if (ed25519Support === null) {
+    ed25519Support = (async () => {
+      try {
+        await crypto.subtle.generateKey('Ed25519', false, ['sign', 'verify']);
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+  }
+  return ed25519Support;
+}
+
 // ── Key Generation ────────────────────────────────────────────────────
 
 /**
  * Generate a new Ed25519 key pair.
+ *
+ * Throws where WebCrypto has no Ed25519 -- see `isEd25519Supported()` for
+ * why there is no fallback, and for how to check before you get here.
+ *
  * @param {boolean} [extractable=false] - Whether private key can be exported
  * @returns {Promise<CryptoKeyPair>} { publicKey, privateKey }
  */
 export async function generateKeyPair(extractable = false) {
-  return crypto.subtle.generateKey('Ed25519', extractable, ['sign', 'verify']);
+  try {
+    return await crypto.subtle.generateKey('Ed25519', extractable, ['sign', 'verify']);
+  } catch (err) {
+    // The platform's own message is typically "Unrecognized name" or a
+    // bare "Type error", neither of which says which algorithm, which
+    // library wanted it, or what a caller might do instead.
+    throw new Error(
+      'wsh requires WebCrypto Ed25519, which this runtime does not implement ' +
+      '(Safari 17+, Chrome/Edge 137+, Firefox 130+, Node 20+). Check ' +
+      'isEd25519Supported() first and fall back to password auth, or supply ' +
+      `a CryptoKeyPair from elsewhere. (${err?.message || err})`,
+      { cause: err }
+    );
+  }
 }
 
 // ── Export / Import ───────────────────────────────────────────────────

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -1621,6 +1621,16 @@ export class WshClient {
     if (hint === 'ws') {
       return [{ kind: 'ws', url }];
     }
+    if (hint !== undefined && hint !== null && hint !== 'auto') {
+      // Anything else is a typo, and silently treating it as 'auto' is
+      // the worst available answer: `transport: 'webtransport'` would
+      // quietly fall back to WebSocket, dropping any
+      // `webTransport.serverCertificateHashes` pin along with it and
+      // connecting over a transport the caller explicitly tried to avoid.
+      throw new Error(
+        `Unknown transport hint: ${JSON.stringify(hint)} (expected 'wt', 'ws', or 'auto')`
+      );
+    }
     if (/^wss?:\/\//i.test(url)) {
       return [{ kind: 'ws', url }];
     }

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -52,6 +52,34 @@ const STATE_CLOSED        = 'closed';
 
 const DEFAULT_AUTH_TIMEOUT   = 10_000;  // ms
 const DEFAULT_OPEN_TIMEOUT   = 10_000;  // ms
+
+/**
+ * Reject a missing argument that maps to a `required: true` wire field.
+ *
+ * JavaScript will happily let an omitted argument through, and
+ * `cborEncode` turns the resulting `undefined` into CBOR null rather
+ * than dropping the key -- so the message goes out looking well-formed,
+ * gets rejected by a spec-conformant server for a reason that has
+ * nothing to do with what the caller did wrong, and the local stack
+ * trace is long gone by then. This is exactly how `resumeSession()`
+ * shipped broken for two releases (CHANGELOG 0.14.0: `last_seq`
+ * "previously always sent as `undefined`, which the wire's
+ * `required: true` field never tolerated"). Failing here instead names
+ * the argument at the call site.
+ *
+ * @param {string} method - Method name, for the message.
+ * @param {Record<string, *>} args - Argument name -> value.
+ */
+function requireArgs(method, args) {
+  for (const [name, value] of Object.entries(args)) {
+    if (value === undefined || value === null) {
+      throw new TypeError(
+        `${method}: "${name}" is required -- the corresponding wire field is not optional, ` +
+        'and omitting it produces a message a conformant server will reject'
+      );
+    }
+  }
+}
 const DEFAULT_PING_INTERVAL  = 30_000;  // ms
 const DEFAULT_EXEC_TIMEOUT   = 60_000;  // ms
 const FILE_CHUNK_SIZE        = 65_536;
@@ -1145,12 +1173,15 @@ export class WshClient {
    * Call an MCP tool on the remote server.
    *
    * @param {string} name - Tool name
-   * @param {object} args - Tool arguments
+   * @param {object} [args={}] - Tool arguments. Defaults to `{}` rather
+   *   than being omitted: `McpCall.arguments` is a required wire field,
+   *   and a tool that takes no arguments is an ordinary thing to call.
    * @param {number} [timeout=30000]
    * @returns {Promise<*>} Tool result
    */
-  async callTool(name, args, timeout = 30_000) {
+  async callTool(name, args = {}, timeout = 30_000) {
     this.#assertAuthenticated('callTool');
+    requireArgs('callTool', { name });
 
     await this.#transport.sendControl(
       mcpCallMsg({ tool: name, arguments: args })
@@ -1216,6 +1247,7 @@ export class WshClient {
    */
   async inviteGuest(sessionId, ttl, permissions = ['read'], timeout = DEFAULT_OPEN_TIMEOUT) {
     this.#assertAuthenticated('inviteGuest');
+    requireArgs('inviteGuest', { sessionId, ttl });
     await this.#transport.sendControl(guestInviteMsg({ sessionId, ttl, permissions }));
     return this.#waitForMessage(
       [MSG.GUEST_INVITE],
@@ -1257,12 +1289,17 @@ export class WshClient {
    * Share a session for multi-attach.
    * @param {string} sessionId - Session to share
    * @param {string} [mode='read'] - Share mode
-   * @param {number} [ttl] - Share TTL in seconds
+   * @param {number} ttl - Share lifetime in seconds. Not optional,
+   *   despite its position after a defaulted parameter:
+   *   `ShareSession.ttl` is a required wire field, and there is no
+   *   sensible default lifetime for a share link to invent on the
+   *   caller's behalf.
    * @param {number} [timeout=10000]
    * @returns {Promise<object>} Share response with share_id
    */
   async shareSession(sessionId, mode = 'read', ttl, timeout = DEFAULT_OPEN_TIMEOUT) {
     this.#assertAuthenticated('shareSession');
+    requireArgs('shareSession', { sessionId, ttl });
     await this.#transport.sendControl(shareSessionMsg({ sessionId, mode, ttl }));
     return this.#waitForMessage(
       [MSG.SHARE_SESSION],
@@ -1310,6 +1347,7 @@ export class WshClient {
    */
   async setRateControl(sessionId, maxBytesPerSec, policy = 'pause') {
     this.#assertAuthenticated('setRateControl');
+    requireArgs('setRateControl', { sessionId, maxBytesPerSec });
     await this.#transport.sendControl(rateControlMsg({ sessionId, maxBytesPerSec, policy }));
   }
 
@@ -1349,6 +1387,7 @@ export class WshClient {
    */
   async copilotAttach(sessionId, model, contextWindow) {
     this.#assertAuthenticated('copilotAttach');
+    requireArgs('copilotAttach', { sessionId, model });
     await this.#transport.sendControl(
       copilotAttachMsg({ sessionId, model, contextWindow })
     );
@@ -1551,6 +1590,7 @@ export class WshClient {
    */
   async updatePolicy(policyId, rules, version) {
     this.#assertAuthenticated('updatePolicy');
+    requireArgs('updatePolicy', { policyId, rules, version });
     await this.#transport.sendControl(
       policyUpdateMsg({ policyId, rules, version })
     );

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -342,10 +342,18 @@ export class WshClient {
    * @param {CryptoKeyPair} [opts.keyPair] - Ed25519 key pair for pubkey auth
    * @param {string} [opts.password] - Password for password auth
    * @param {'wt'|'ws'|'auto'} [opts.transport] - Force a specific transport
+   * @param {object} [opts.webTransport] - Options forwarded to the
+   *   `WebTransport` constructor when the WebTransport rung of the ladder
+   *   is tried. Most usefully `serverCertificateHashes`, which pins a
+   *   specific self-signed certificate by SHA-256 digest -- the one way
+   *   page JavaScript can reach a server whose certificate no certificate
+   *   authority signed. Values may be raw bytes, hex (colon-separated is
+   *   fine), or base64. Ignored by the WebSocket rung, which has no
+   *   equivalent mechanism.
    * @param {number} [opts.timeout] - Auth handshake timeout in ms
    * @returns {Promise<string>} The server-assigned session ID
    */
-  async connect(url, { username, keyPair, password, transport: transportHint, timeout = DEFAULT_AUTH_TIMEOUT } = {}) {
+  async connect(url, { username, keyPair, password, transport: transportHint, webTransport, timeout = DEFAULT_AUTH_TIMEOUT } = {}) {
     if (this.#state !== STATE_DISCONNECTED && this.#state !== STATE_CLOSED) {
       throw new Error(`Client already ${this.#state}`);
     }
@@ -365,7 +373,7 @@ export class WshClient {
 
     try {
       // ── Select and connect transport ──────────────────────────────
-      const transport = await this.#connectTransport(url, transportHint);
+      const transport = await this.#connectTransport(url, transportHint, webTransport);
       this.#transport = transport;
       this.#state = STATE_CONNECTED;
 
@@ -834,6 +842,7 @@ export class WshClient {
     username,
     keyPair,
     password,
+    webTransport,
     expose = {},
     peerType = 'browser-shell',
     shellBackend,
@@ -843,7 +852,7 @@ export class WshClient {
     supportsTermSync,
   } = {}) {
     // Authenticate normally first.
-    const sessionId = await this.connect(url, { username, keyPair, password });
+    const sessionId = await this.connect(url, { username, keyPair, password, webTransport });
 
     // Build capabilities list from expose options.
     const capabilities = [];
@@ -1554,17 +1563,23 @@ export class WshClient {
    *
    * @param {string} url
    * @param {'wt'|'ws'|'auto'} [hint]
+   * @param {object} [webTransport] - Options for the `WebTransport`
+   *   constructor, applied only to a `wt` attempt (see
+   *   `WebTransportTransport`). The `ws` rung of the ladder ignores them:
+   *   a `serverCertificateHashes` pin has no WebSocket equivalent, so a
+   *   `wss:` fallback against that same self-signed certificate will
+   *   still fail the usual certificate-authority check.
    * @returns {Promise<import('./transport.mjs').WshTransport>}
    * @private
    */
-  async #connectTransport(url, hint) {
+  async #connectTransport(url, hint, webTransport) {
     const attempts = this.#buildTransportAttempts(url, hint);
     const errors = [];
 
     for (const attempt of attempts) {
       const transport = this.#createTransport(attempt.kind);
       try {
-        await transport.connect(attempt.url);
+        await transport.connect(attempt.url, attempt.kind === 'wt' ? webTransport : undefined);
         this.#attachTransportHandlers(transport);
         return transport;
       } catch (err) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -817,7 +817,19 @@ export function isValidMessage(msg: unknown): boolean;
 // ============================================================================
 
 /**
- * Generate a new Ed25519 key pair.
+ * Whether this runtime's WebCrypto implements Ed25519, measured by
+ * generating a key rather than sniffed from a version string.
+ *
+ * There is no pure-JS fallback: one would need the private scalar as
+ * ordinary bytes, giving up the non-extractable `CryptoKey` property
+ * `WshKeyStore` is built around. Check this before committing to pubkey
+ * auth and fall back to password auth where it returns false.
+ */
+export function isEd25519Supported(): Promise<boolean>;
+
+/**
+ * Generate a new Ed25519 key pair. Throws with an actionable message
+ * where WebCrypto has no Ed25519 -- see `isEd25519Supported()`.
  * @param extractable - Whether private key can be exported (default false)
  */
 export function generateKeyPair(extractable?: boolean): Promise<CryptoKeyPair>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1017,7 +1017,7 @@ export class WshTransport {
   readonly state: 'disconnected' | 'connecting' | 'connected' | 'closed';
 
   /** Connect to a wsh server. */
-  connect(url: string): Promise<void>;
+  connect(url: string, options?: object): Promise<void>;
 
   /** Gracefully close the transport. */
   close(): Promise<void>;
@@ -1044,7 +1044,7 @@ export class WshTransport {
   protected _emitError(err: Error): void;
 
   /** @protected Must be overridden by subclasses. */
-  protected _doConnect(url: string): Promise<void>;
+  protected _doConnect(url: string, options?: object): Promise<void>;
 
   /** @protected Must be overridden by subclasses. */
   protected _doClose(): Promise<void>;
@@ -1064,7 +1064,65 @@ export class WshTransport {
  * - Subsequent streams carry raw byte data (no framing).
  * - Server-initiated streams are surfaced via onStreamOpen.
  */
-export class WebTransportTransport extends WshTransport {}
+export class WebTransportTransport extends WshTransport {
+  /**
+   * @param options Forwarded to the `WebTransport` constructor. Options
+   *   passed to `connect()` override these per call.
+   */
+  constructor(options?: WshWebTransportOptions);
+
+  connect(url: string, options?: WshWebTransportOptions): Promise<void>;
+}
+
+/**
+ * One entry of `serverCertificateHashes`. The digest may be given as raw
+ * bytes, as hex (with or without `:` separators -- what
+ * `openssl x509 -fingerprint -sha256` prints), or as base64/base64url.
+ */
+export interface WshCertificateHash {
+  /** Defaults to `'sha-256'`, the only algorithm the platform accepts today. */
+  algorithm?: string;
+  value: BufferSource | string;
+}
+
+/**
+ * Options forwarded to the `WebTransport` constructor.
+ *
+ * `serverCertificateHashes` is the interesting one: it pins a specific
+ * self-signed certificate by digest, which is the only mechanism in the
+ * web platform that lets page JavaScript reach a server whose certificate
+ * no certificate authority signed. The platform's own constraints apply --
+ * `https:` URL, HTTP/3 only, ECDSA P-256 key, at most 14 days validity,
+ * no connection pooling.
+ *
+ * Every other key is forwarded verbatim, so platform options not listed
+ * here still work.
+ */
+export interface WshWebTransportOptions {
+  serverCertificateHashes?: Array<WshCertificateHash | BufferSource | string>;
+  allowPooling?: boolean;
+  requireUnreliable?: boolean;
+  congestionControl?: 'default' | 'throughput' | 'low-latency';
+  anticipatedConcurrentIncomingUnidirectionalStreams?: number | null;
+  anticipatedConcurrentIncomingBidirectionalStreams?: number | null;
+  protocols?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * Decode one `serverCertificateHashes` digest into bytes. Accepts a
+ * `BufferSource`, hex (separators and an `... Fingerprint=` prefix are
+ * stripped), or base64/base64url. Throws a `TypeError` on an
+ * unrecognised shape and a `RangeError` on a digest of the wrong length
+ * for the algorithm.
+ */
+export function parseCertificateHash(value: BufferSource | string, algorithm?: string): Uint8Array;
+
+/**
+ * Normalise a caller-supplied options bag into a `WebTransportOptions`
+ * dictionary, or `undefined` when there is nothing to pass.
+ */
+export function normalizeWebTransportOptions(options?: WshWebTransportOptions): object | undefined;
 
 /**
  * Dispatch a fixed, already-available batch of items one at a time,
@@ -1427,6 +1485,12 @@ export interface WshConnectOptions {
   keyPair?: CryptoKeyPair;
   password?: string;
   transport?: 'wt' | 'ws';
+  /**
+   * Forwarded to the `WebTransport` constructor when the WebTransport
+   * rung of the transport ladder is tried; ignored by the WebSocket rung,
+   * which has no `serverCertificateHashes` equivalent.
+   */
+  webTransport?: WshWebTransportOptions;
   timeout?: number;
 }
 
@@ -1466,6 +1530,8 @@ export interface WshConnectReverseOptions {
   username: string;
   keyPair?: CryptoKeyPair;
   password?: string;
+  /** Forwarded to the underlying `connect()` -- see `WshConnectOptions`. */
+  webTransport?: WshWebTransportOptions;
   expose?: {
     shell?: boolean;
     exec?: boolean;

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -42,6 +42,7 @@ export {
 
 // Auth + crypto
 export {
+  isEd25519Supported,
   generateKeyPair, exportPublicKeyRaw, exportPublicKeySSH,
   importPublicKeyRaw, exportPrivateKeyPKCS8, importPrivateKeyPKCS8,
   sign, verify, buildTranscript, signChallenge, verifyChallenge,

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -51,7 +51,10 @@ export {
 } from './auth.mjs';
 
 // Transport
-export { WshTransport, WebTransportTransport, dispatchSerially, SerialQueue } from './transport.mjs';
+export {
+  WshTransport, WebTransportTransport, dispatchSerially, SerialQueue,
+  parseCertificateHash, normalizeWebTransportOptions,
+} from './transport.mjs';
 export { WebSocketTransport, WS_FRAME_TYPE } from './transport-ws.mjs';
 
 // QMux (QUIC-v1 frames over an ordered byte stream, draft-ietf-quic-qmux-02)

--- a/src/transport-ws.mjs
+++ b/src/transport-ws.mjs
@@ -214,8 +214,22 @@ export class WebSocketTransport extends WshTransport {
     // own stream objects -- without this, any reader still waiting on a
     // stream's readable side would hang forever, since nothing else
     // errors or closes it once the peer can no longer respond.
-    this.#qmux?.close();
-    this.#qmux?.destroy(new Error('Transport closed'));
+    //
+    // Each step is guarded separately. The courtesy CONNECTION_CLOSE is
+    // the one that can realistically throw -- it writes to the socket,
+    // and a socket that is already broken is the single most likely
+    // reason we are closing at all. Letting that throw would skip both
+    // the local `destroy()` (hanging every waiting reader, the exact
+    // thing above) and the socket close (leaking the connection), which
+    // makes the failure mode strictly worse than the failure that
+    // triggered it.
+    try {
+      this.#qmux?.close();
+    } catch { /* peer is unreachable; the local teardown below still matters */ }
+
+    try {
+      this.#qmux?.destroy(new Error('Transport closed'));
+    } catch { /* a stream's error callback threw; keep tearing down */ }
 
     if (this.#ws) {
       try {

--- a/src/transport.mjs
+++ b/src/transport.mjs
@@ -158,7 +158,26 @@ export class WshTransport {
       await this._doConnect(url, options);
       this.#state = STATE_CONNECTED;
     } catch (err) {
+      // A connect can fail *after* acquiring a real resource -- an open
+      // WebSocket whose QMux handshake then threw, a WebTransport whose
+      // session came up but whose control stream did not. Tear that down
+      // here, because a later `close()` cannot: it treats the `closed`
+      // state this line sets as "already torn down" and returns without
+      // calling `_doClose()`, so the socket would stay open for the life
+      // of the page. Every rung of WshClient's transport ladder that
+      // fails hits this path.
       this.#state = STATE_CLOSED;
+      try {
+        await this._doClose();
+      } catch {
+        // Best effort: the connect error is the one worth reporting, and
+        // tearing down a half-built transport can fail for its own
+        // uninteresting reasons.
+      }
+      // Deliberately no `_emitClose()`: a transport that never reached
+      // `connected` never announced itself, callers have not attached
+      // their handlers yet, and a close event for a connection that never
+      // opened is a lie.
       throw err;
     }
   }

--- a/src/transport.mjs
+++ b/src/transport.mjs
@@ -111,7 +111,7 @@ const STATE_CLOSED       = 'closed';
  * Abstract transport for the wsh protocol.
  *
  * Subclasses must implement:
- *   - _doConnect(url)
+ *   - _doConnect(url, options)
  *   - _doClose()
  *   - _doSendControl(msg)
  *   - _doOpenStream()
@@ -144,14 +144,18 @@ export class WshTransport {
   /**
    * Connect to a wsh server.
    * @param {string} url
+   * @param {object} [options] - Transport-specific connect options.
+   *   Ignored by transports that have none; `WebTransportTransport`
+   *   forwards them to the `WebTransport` constructor (see its docs for
+   *   `serverCertificateHashes`).
    */
-  async connect(url) {
+  async connect(url, options) {
     if (this.#state === STATE_CONNECTED || this.#state === STATE_CONNECTING) {
       throw new Error(`Transport already ${this.#state}`);
     }
     this.#state = STATE_CONNECTING;
     try {
-      await this._doConnect(url);
+      await this._doConnect(url, options);
       this.#state = STATE_CONNECTED;
     } catch (err) {
       this.#state = STATE_CLOSED;
@@ -235,7 +239,7 @@ export class WshTransport {
   // ── Abstract methods (must be overridden) ────────────────────────────
 
   /** @protected */
-  async _doConnect(_url) {
+  async _doConnect(_url, _options) {
     throw new Error('_doConnect not implemented');
   }
 
@@ -256,6 +260,140 @@ export class WshTransport {
 }
 
 // ── WebTransport implementation ──────────────────────────────────────
+
+// ── WebTransport options ─────────────────────────────────────────────
+
+/** Digest length in bytes, keyed by the algorithm name WebTransport accepts. */
+const CERT_HASH_LENGTHS = Object.freeze({ 'sha-256': 32 });
+
+/**
+ * Decode one `serverCertificateHashes` value into the `BufferSource` the
+ * WebTransport constructor requires.
+ *
+ * Accepts, in addition to a `BufferSource` passed straight through:
+ *
+ * - **Hex**, with or without separators — this is what
+ *   `openssl x509 -fingerprint -sha256` prints
+ *   (`SHA256 Fingerprint=AB:CD:...`), and pasting that string in is the
+ *   single most likely thing a caller will try.
+ * - **Base64** or **base64url**, which is how the same digest usually
+ *   arrives over a QR code or a pairing payload.
+ *
+ * Throws on anything else, and on a digest whose decoded length is wrong
+ * for the algorithm. Failing here is the whole point: a wrong hash
+ * otherwise surfaces as an opaque `WebTransportError` from `wt.ready`
+ * with no indication that the *input* was malformed rather than the
+ * certificate mismatched.
+ *
+ * @param {*} value
+ * @param {string} algorithm - Lower-cased algorithm name (e.g. 'sha-256').
+ * @returns {Uint8Array}
+ */
+export function parseCertificateHash(value, algorithm = 'sha-256') {
+  const expected = CERT_HASH_LENGTHS[algorithm];
+  let bytes;
+
+  if (value instanceof Uint8Array) {
+    bytes = value;
+  } else if (ArrayBuffer.isView(value)) {
+    bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  } else if (value instanceof ArrayBuffer) {
+    bytes = new Uint8Array(value);
+  } else if (typeof value === 'string') {
+    bytes = decodeHashString(value);
+  } else {
+    throw new TypeError(
+      'serverCertificateHashes value must be a BufferSource or a hex/base64 string, ' +
+      `got ${value === null ? 'null' : typeof value}`
+    );
+  }
+
+  if (expected !== undefined && bytes.length !== expected) {
+    throw new RangeError(
+      `serverCertificateHashes value for "${algorithm}" must be ${expected} bytes, got ${bytes.length}`
+    );
+  }
+  return bytes;
+}
+
+/**
+ * @param {string} str
+ * @returns {Uint8Array}
+ */
+function decodeHashString(str) {
+  // Strip the separators OpenSSL and friends emit, plus any surrounding
+  // whitespace: "SHA256 Fingerprint=" style output is colon-separated,
+  // and hand-copied values often carry spaces or dashes.
+  const compact = str.trim().replace(/^[^=]*fingerprint[^=]*=\s*/i, '');
+  const hexish = compact.replace(/[\s:-]/g, '');
+
+  if (/^[0-9a-fA-F]+$/.test(hexish) && hexish.length % 2 === 0) {
+    const out = new Uint8Array(hexish.length / 2);
+    for (let i = 0; i < out.length; i++) {
+      out[i] = Number.parseInt(hexish.slice(i * 2, i * 2 + 2), 16);
+    }
+    return out;
+  }
+
+  // Not hex — try base64 / base64url.
+  const b64 = compact.replace(/-/g, '+').replace(/_/g, '/');
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(b64)) {
+    throw new TypeError(
+      `serverCertificateHashes value is neither hex nor base64: ${JSON.stringify(str)}`
+    );
+  }
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Normalise a caller-supplied options bag into a `WebTransportOptions`
+ * dictionary, or `undefined` when there is nothing to pass.
+ *
+ * Only `serverCertificateHashes` is transformed; every other key is
+ * forwarded verbatim, so options the platform gains later
+ * (`congestionControl`, `allowPooling`, `requireUnreliable`, the
+ * `anticipatedConcurrentIncoming*Streams` hints, …) work without a
+ * change here.
+ *
+ * @param {object} [options]
+ * @returns {object|undefined}
+ */
+export function normalizeWebTransportOptions(options) {
+  if (!options) return undefined;
+  const keys = Object.keys(options).filter((k) => options[k] !== undefined);
+  if (keys.length === 0) return undefined;
+
+  const out = {};
+  for (const key of keys) out[key] = options[key];
+
+  if (out.serverCertificateHashes !== undefined) {
+    const list = out.serverCertificateHashes;
+    if (!Array.isArray(list)) {
+      throw new TypeError('serverCertificateHashes must be an array');
+    }
+    if (list.length === 0) {
+      throw new TypeError(
+        'serverCertificateHashes must not be empty -- omit the option entirely to use the ' +
+        'normal certificate-authority path'
+      );
+    }
+    out.serverCertificateHashes = list.map((entry) => {
+      if (entry === null || typeof entry !== 'object' || Array.isArray(entry) ||
+          ArrayBuffer.isView(entry) || entry instanceof ArrayBuffer) {
+        // A bare digest is a natural thing to write; accept it rather
+        // than making the caller wrap every value in { algorithm, value }.
+        return { algorithm: 'sha-256', value: parseCertificateHash(entry, 'sha-256') };
+      }
+      const algorithm = String(entry.algorithm ?? 'sha-256').toLowerCase();
+      return { algorithm, value: parseCertificateHash(entry.value, algorithm) };
+    });
+  }
+
+  return out;
+}
 
 /**
  * wsh transport over the WebTransport API.
@@ -287,16 +425,53 @@ export class WebTransportTransport extends WshTransport {
   /** @type {Promise<void>} Resolves when the incoming-stream acceptor finishes. */
   #incomingAcceptorDone = null;
 
+  /** @type {object|undefined} Default WebTransport options for every connect. */
+  #options;
+
+  /**
+   * @param {object} [options] - Forwarded to the `WebTransport`
+   *   constructor. Most usefully `serverCertificateHashes`, which lets
+   *   page JavaScript pin a specific short-lived self-signed certificate
+   *   by digest instead of requiring one a certificate authority signed:
+   *
+   *   ```js
+   *   new WebTransportTransport({
+   *     serverCertificateHashes: [
+   *       // hex (with or without colons), base64, or raw bytes
+   *       'a1:b2:c3:...',
+   *     ],
+   *   });
+   *   ```
+   *
+   *   The web platform imposes the rules, not wsh: the URL must be
+   *   `https:`, the connection is HTTP/3 only (there is no fallback to
+   *   HTTP/2 for a pinned certificate), the certificate must use an
+   *   ECDSA P-256 key and be valid for no more than 14 days, and
+   *   connection pooling is disabled. Options passed to `connect()`
+   *   override these per call.
+   */
+  constructor(options) {
+    super();
+    this.#options = options;
+  }
+
   // ── Lifecycle ──────────────────────────────────────────────────────
 
   /** @override */
-  async _doConnect(url) {
+  async _doConnect(url, options) {
     this.#abort = new AbortController();
     this.#decoder.reset();
     this.#nextStreamId = 1;
 
-    // Create the WebTransport session.
-    const wt = new WebTransport(url);
+    // Create the WebTransport session. Pass the options dictionary only
+    // when there is something in it: `new WebTransport(url)` and
+    // `new WebTransport(url, {})` are equivalent per spec, but an empty
+    // second argument is noise in a stack trace and in any engine that
+    // predates the dictionary.
+    const wtOptions = normalizeWebTransportOptions(
+      (this.#options || options) && { ...this.#options, ...options }
+    );
+    const wt = wtOptions ? new WebTransport(url, wtOptions) : new WebTransport(url);
     this.#wt = wt;
 
     // Wait for the connection to be ready.

--- a/test/auth.test.mjs
+++ b/test/auth.test.mjs
@@ -238,3 +238,53 @@ describe('auth', { skip: !hasEd25519 && 'Ed25519 not available in this runtime' 
     assert.ok(valid);
   });
 });
+
+describe('Ed25519 capability floor', { skip: !hasEd25519 && 'Ed25519 not available in this runtime' }, () => {
+  // wsh has no pure-JS Ed25519 fallback -- deliberately, because one
+  // would need the private scalar as ordinary bytes and give up the
+  // non-extractable CryptoKey property WshKeyStore is built around. What
+  // it owes callers instead is a way to ask, and a comprehensible failure
+  // where the answer is no.
+
+  it('isEd25519Supported() reports true on a runtime that has it', async () => {
+    assert.equal(await auth.isEd25519Supported(), true);
+  });
+
+  it('isEd25519Supported() memoizes rather than re-probing', async () => {
+    const first = auth.isEd25519Supported();
+    const second = auth.isEd25519Supported();
+    assert.equal(await first, await second);
+  });
+
+  it('generateKeyPair() explains the floor instead of forwarding "Unrecognized name"', async () => {
+    const original = crypto.subtle.generateKey;
+    crypto.subtle.generateKey = async () => {
+      const err = new Error('Unrecognized name.');
+      err.name = 'NotSupportedError';
+      throw err;
+    };
+    try {
+      await assert.rejects(
+        () => auth.generateKeyPair(),
+        (err) => {
+          // The message must name the missing primitive, the versions
+          // that have it, and what a caller can do instead -- none of
+          // which the platform's own error says.
+          assert.match(err.message, /WebCrypto Ed25519/);
+          assert.match(err.message, /Safari 17\+/);
+          assert.match(err.message, /isEd25519Supported/);
+          assert.equal(err.cause?.name, 'NotSupportedError');
+          return true;
+        }
+      );
+    } finally {
+      crypto.subtle.generateKey = original;
+    }
+  });
+
+  it('a working runtime is unaffected by that wrapping', async () => {
+    const keyPair = await auth.generateKeyPair(true);
+    assert.ok(keyPair.publicKey);
+    assert.ok(keyPair.privateKey);
+  });
+});

--- a/test/spec-conformance.test.mjs
+++ b/test/spec-conformance.test.mjs
@@ -1,0 +1,290 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { WshTransport } from '../src/transport.mjs';
+import { MSG } from '../src/messages.gen.mjs';
+import { cborEncode, cborDecode } from '../src/cbor.mjs';
+import { WshClient } from '../src/client.mjs';
+import { generateKeyPair } from '../src/auth.mjs';
+
+// Every other test in this repo checks the client against a stand-in
+// that answers whatever the client asked for. This one checks it against
+// spec/wsh-v1.yaml, which is the only party in the room that cannot be
+// talked around.
+//
+// The failure it exists to catch has already happened once. From
+// CHANGELOG 0.14.0, on `resumeSession()`: `lastSeq` was "previously
+// always sent as `undefined`, which the wire's `required: true` field
+// never tolerated -- so `resumeSession()` could never have produced a
+// valid `Resume` message before this fix either." 443 tests passed
+// throughout, because the message went out looking structurally fine and
+// the mock on the other end had no opinion about `required`.
+//
+// So: drive the public API, capture what actually goes on the wire, and
+// hold it against the field requirements the spec declares.
+
+const SPEC_PATH = fileURLToPath(new URL('../spec/wsh-v1.yaml', import.meta.url));
+
+/**
+ * Extract `{ code, required[] }` per message from the spec YAML.
+ *
+ * A hand-rolled reader rather than a YAML dependency: this package has
+ * no runtime dependencies and the spec is a fixed-indentation subset.
+ * `parseSpecSanity` below fails loudly if the extraction ever stops
+ * matching the document, so a parser that quietly reads nothing cannot
+ * turn this file into a suite of vacuous passes.
+ */
+function loadSpecRequirements(path) {
+  const lines = readFileSync(path, 'utf8').split('\n');
+  const byName = {};
+  let inMessages = false;
+  let msg = null;
+  let inFields = false;
+  let field = null;
+
+  for (const raw of lines) {
+    if (raw.trim() === '' || /^\s*#/.test(raw)) continue;
+    const indent = raw.match(/^ */)[0].length;
+    const text = raw.trim();
+
+    if (indent === 0) {                       // top-level key
+      inMessages = text === 'messages:';
+      msg = field = null;
+      inFields = false;
+    } else if (!inMessages) {
+      continue;
+    } else if (indent === 2 && text.endsWith(':')) {   // category
+      msg = field = null;
+      inFields = false;
+    } else if (indent === 4 && text.endsWith(':')) {   // message name
+      msg = text.slice(0, -1);
+      byName[msg] = { name: msg, code: null, required: [] };
+      inFields = false;
+      field = null;
+    } else if (indent === 6) {                          // message attribute
+      inFields = text === 'fields:';
+      const code = text.match(/^code:\s*(\S+)/);
+      if (code && msg) byName[msg].code = Number(code[1]);
+      field = null;
+    } else if (indent === 8 && inFields && text.endsWith(':')) {  // field name
+      field = text.slice(0, -1);
+    } else if (indent >= 10 && field && /^required:\s*true\b/.test(text)) {
+      byName[msg].required.push(field);
+    }
+  }
+
+  const byCode = new Map();
+  for (const m of Object.values(byName)) {
+    if (m.code !== null) byCode.set(m.code, m);
+  }
+  return { byName, byCode };
+}
+
+let spec;
+before(() => { spec = loadSpecRequirements(SPEC_PATH); });
+
+describe('the spec reader actually read the spec', () => {
+  // Without these, a parser bug would make every assertion below pass by
+  // finding nothing to check.
+  it('finds the full set of message types the README advertises', () => {
+    assert.equal(Object.keys(spec.byName).length, 95);
+    assert.equal(spec.byCode.size, 95);
+  });
+
+  it('agrees with messages.gen.mjs about opcodes', () => {
+    assert.equal(spec.byName.Hello.code, MSG.HELLO);
+    assert.equal(spec.byName.Resume.code, MSG.RESUME);
+    assert.equal(spec.byName.RateControl.code, MSG.RATE_CONTROL);
+    assert.equal(spec.byName.PolicyUpdate.code, MSG.POLICY_UPDATE);
+  });
+
+  it('reads required-field sets, including the one that shipped broken', () => {
+    assert.deepEqual(spec.byName.Resume.required, ['session_id', 'token', 'last_seq']);
+    assert.deepEqual(spec.byName.Attach.required, ['session_id']);
+    assert.deepEqual(spec.byName.Hello.required, ['version', 'username']);
+    assert.deepEqual(spec.byName.PolicyUpdate.required, ['policy_id', 'rules', 'version']);
+  });
+
+  it('distinguishes required from optional and defaulted fields', () => {
+    // Attach.token is optional (clawser #48) and Attach.mode is defaulted;
+    // neither may show up as required.
+    assert.ok(!spec.byName.Attach.required.includes('token'));
+    assert.ok(!spec.byName.Attach.required.includes('mode'));
+    assert.ok(!spec.byName.RateControl.required.includes('policy'));
+  });
+});
+
+describe('an omitted required field does not vanish -- it becomes CBOR null', () => {
+  it('encodes as a present key with a null value, not as an absent key', () => {
+    const encoded = cborEncode({ type: MSG.RATE_CONTROL, session_id: 's', max_bytes_per_sec: undefined });
+    const decoded = cborDecode(encoded);
+    assert.ok('max_bytes_per_sec' in decoded, 'the key survives the round trip');
+    assert.equal(decoded.max_bytes_per_sec, null);
+  });
+});
+
+const hasEd25519 = typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined';
+
+/** Records outbound control messages; answers only what the handshake needs. */
+class RecordingTransport extends WshTransport {
+  sent = [];
+
+  async _doConnect() {}
+  async _doClose() {}
+  async _doOpenStream() { throw new Error('not needed'); }
+
+  async _doSendControl(msg) {
+    this.sent.push(msg);
+    const reply = (m) => setTimeout(() => this._emitControl(m), 0);
+    switch (msg.type) {
+      case MSG.HELLO:
+        reply({ type: MSG.CHALLENGE, nonce: new Uint8Array(32).fill(7), session_id: 'sid' });
+        break;
+      case MSG.AUTH:
+        reply({ type: MSG.AUTH_OK, session_id: 'sid' });
+        break;
+      // Deliberately nothing else: these tests care about what the client
+      // *sends*, and a reply this transport invents would only be an
+      // opinion about what the client wanted to hear.
+      default:
+        break;
+    }
+  }
+}
+
+describe('outbound messages satisfy the spec', { skip: !hasEd25519 && 'Ed25519 not available' }, () => {
+  /** @returns {Promise<{ client: WshClient, transport: RecordingTransport }>} */
+  async function connected() {
+    const keyPair = await generateKeyPair(true);
+    const transport = new RecordingTransport();
+    const client = new WshClient();
+    await client.connectWithTransport(transport, 'wsh://example.test/wsh', {
+      username: 'alice',
+      keyPair,
+    });
+    return { client, transport };
+  }
+
+  /** Assert every captured message carries every field the spec requires. */
+  function assertConformant(transport, label) {
+    assert.ok(transport.sent.length > 0, `${label}: nothing was sent`);
+    for (const msg of transport.sent) {
+      const definition = spec.byCode.get(msg.type);
+      assert.ok(definition, `${label}: opcode 0x${msg.type.toString(16)} is not in the spec`);
+      const missing = definition.required.filter((f) => msg[f] === undefined || msg[f] === null);
+      assert.deepEqual(
+        missing,
+        [],
+        `${label}: ${definition.name} is missing required field(s) ${missing.join(', ')}`
+      );
+    }
+  }
+
+  it('the handshake itself is conformant', async () => {
+    const { transport } = await connected();
+    assertConformant(transport, 'handshake');
+  });
+
+  // Every method below is called with only the arguments its own JSDoc
+  // marks as required. That is the shape the resumeSession() bug took:
+  // the library, calling its own message constructor, left a required
+  // wire field undefined.
+  const minimalCalls = [
+    ['attachSession', (c) => c.attachSession('sess-1')],
+    ['resumeSession', (c) => c.resumeSession('sess-1', new Uint8Array(32))],
+    ['detach', (c) => c.detach('sess-1')],
+    ['listRemoteSessions', (c) => c.listRemoteSessions()],
+    ['discoverTools', (c) => c.discoverTools()],
+    ['callTool', (c) => c.callTool('some-tool')],
+    ['requestMetrics', (c) => c.requestMetrics()],
+    ['listPeers', (c) => c.listPeers()],
+    ['joinAsGuest', (c) => c.joinAsGuest(new Uint8Array(16))],
+    ['negotiateCompression', (c) => c.negotiateCompression('zstd')],
+    ['evaluatePolicy', (c) => c.evaluatePolicy('exec', 'alice')],
+    ['fileStat', (c) => c.fileStat('/tmp/x')],
+    ['fileRead', (c) => c.fileRead('/tmp/x')],
+    ['fileWrite', (c) => c.fileWrite('/tmp/x', new Uint8Array(4))],
+    ['fileRename', (c) => c.fileRename('/a', '/b')],
+    ['grantSessionAccess', (c) => c.grantSessionAccess('sess-1', 'bob')],
+    ['revokeSessionAccess', (c) => c.revokeSessionAccess('sess-1', 'bob')],
+    ['suspendSession', (c) => c.suspendSession('sess-1')],
+    ['restartPty', (c) => c.restartPty('sess-1')],
+    ['revokeGuest', (c) => c.revokeGuest(new Uint8Array(16))],
+    ['revokeShare', (c) => c.revokeShare('share-1')],
+    ['linkSession', (c) => c.linkSession('sess-1', 'host', 22)],
+    ['unlinkSession', (c) => c.unlinkSession('link-1')],
+    ['copilotSuggest', (c) => c.copilotSuggest('sess-1', 'try ls')],
+    ['copilotDetach', (c) => c.copilotDetach('sess-1')],
+    ['inviteGuest', (c) => c.inviteGuest('sess-1', 300)],
+    ['shareSession', (c) => c.shareSession('sess-1', 'read', 300)],
+    ['setRateControl', (c) => c.setRateControl('sess-1', 1_000_000)],
+    ['copilotAttach', (c) => c.copilotAttach('sess-1', 'claude-sonnet')],
+    ['updatePolicy', (c) => c.updatePolicy('policy-1', { allow: [] }, 2)],
+  ];
+
+  for (const [name, call] of minimalCalls) {
+    it(`${name}() sends only spec-conformant messages`, async () => {
+      const { client, transport } = await connected();
+      transport.sent.length = 0;
+
+      // Request/reply calls never resolve here on purpose -- this
+      // transport answers nothing after the handshake. What was sent is
+      // already captured by the time the waiter is registered.
+      const pending = call(client);
+      if (pending && typeof pending.then === 'function') {
+        pending.catch(() => {});     // a timeout later is fine and expected
+        await Promise.resolve();
+      }
+      await new Promise((r) => setTimeout(r, 0));
+
+      assertConformant(transport, name);
+      await client.disconnect().catch(() => {});
+    });
+  }
+});
+
+describe('a missing required argument is refused at the call site', { skip: !hasEd25519 && 'Ed25519 not available' }, () => {
+  async function connected() {
+    const keyPair = await generateKeyPair(true);
+    const transport = new RecordingTransport();
+    const client = new WshClient();
+    await client.connectWithTransport(transport, 'wsh://example.test/wsh', {
+      username: 'alice',
+      keyPair,
+    });
+    return { client, transport };
+  }
+
+  const omissions = [
+    ['inviteGuest', (c) => c.inviteGuest('sess-1'), /"ttl" is required/],
+    ['shareSession', (c) => c.shareSession('sess-1'), /"ttl" is required/],
+    ['setRateControl', (c) => c.setRateControl('sess-1'), /"maxBytesPerSec" is required/],
+    ['copilotAttach', (c) => c.copilotAttach('sess-1'), /"model" is required/],
+    ['updatePolicy', (c) => c.updatePolicy('policy-1'), /"rules" is required/],
+  ];
+
+  for (const [name, call, expected] of omissions) {
+    it(`${name}() throws by argument name instead of sending CBOR null`, async () => {
+      const { client, transport } = await connected();
+      transport.sent.length = 0;
+
+      await assert.rejects(() => call(client), expected);
+      assert.deepEqual(transport.sent, [], 'nothing may go on the wire');
+      await client.disconnect().catch(() => {});
+    });
+  }
+
+  it('callTool() defaults its arguments to {} rather than refusing -- a no-argument tool is normal', async () => {
+    const { client, transport } = await connected();
+    transport.sent.length = 0;
+
+    client.callTool('some-tool').catch(() => {});
+    await new Promise((r) => setTimeout(r, 0));
+
+    const call = transport.sent.find((m) => m.type === MSG.MCP_CALL);
+    assert.ok(call, 'the call must still be sent');
+    assert.deepEqual(call.arguments, {});
+    await client.disconnect().catch(() => {});
+  });
+});

--- a/test/transport-ladder.test.mjs
+++ b/test/transport-ladder.test.mjs
@@ -1,0 +1,207 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { WshTransport } from '../src/transport.mjs';
+import { MSG } from '../src/messages.gen.mjs';
+import { WshClient } from '../src/client.mjs';
+import { generateKeyPair } from '../src/auth.mjs';
+
+// `WshClient#buildTransportAttempts` decides which transport is tried,
+// in what order, and against which URL. It is the behaviour a caller
+// depends on most and, until this file, had no test of any kind -- both
+// existing transport suites construct a transport directly and never
+// exercise the choice between them.
+//
+// These tests drive the ladder through the public API, via the
+// documented `transportFactories` injection point. The factories are not
+// a mock server: they record which kind was asked for and which URL it
+// was handed, and can be told to fail. Nothing here answers a protocol
+// question, so nothing here can agree with the client about something
+// they are both wrong about.
+
+const hasEd25519 = typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined';
+
+/**
+ * A transport that records its connect URL, optionally fails, and
+ * otherwise completes the auth handshake so `connect()` resolves.
+ */
+class SpyTransport extends WshTransport {
+  constructor(kind, log, { failWith } = {}) {
+    super();
+    this.kind = kind;
+    this.log = log;
+    this.failWith = failWith;
+  }
+
+  async _doConnect(url, options) {
+    this.log.push({ kind: this.kind, url, options });
+    if (this.failWith) throw new Error(this.failWith);
+  }
+
+  async _doClose() {
+    this.log.push({ kind: this.kind, closed: true });
+  }
+
+  async _doSendControl(msg) {
+    if (msg.type === MSG.HELLO) {
+      setTimeout(() => this._emitControl({
+        type: MSG.CHALLENGE,
+        nonce: new Uint8Array(32).fill(3),
+        session_id: `sid-${this.kind}`,
+      }), 0);
+    } else if (msg.type === MSG.AUTH) {
+      setTimeout(() => this._emitControl({ type: MSG.AUTH_OK }), 0);
+    }
+  }
+
+  async _doOpenStream() {
+    throw new Error('not needed');
+  }
+}
+
+/**
+ * @param {{ wtFails?: string, wsFails?: string }} [opts]
+ * @returns {{ client: WshClient, log: Array }}
+ */
+function makeClient({ wtFails, wsFails } = {}) {
+  const log = [];
+  const client = new WshClient({
+    transportFactories: {
+      wt: () => new SpyTransport('wt', log, { failWith: wtFails }),
+      ws: () => new SpyTransport('ws', log, { failWith: wsFails }),
+    },
+  });
+  return { client, log };
+}
+
+/** Which transport kinds were *connect-attempted*, in order. */
+const attempted = (log) => log.filter((e) => !e.closed).map((e) => e.kind);
+
+describe('WshClient transport ladder', { skip: !hasEd25519 && 'Ed25519 not available' }, () => {
+  let keyPair;
+
+  const connect = async (client, url, extra = {}) => {
+    keyPair ||= await generateKeyPair(true);
+    return client.connect(url, { username: 'u', keyPair, ...extra });
+  };
+
+  it('a bare host URL tries WebTransport first, then falls back to WebSocket', async () => {
+    const { client, log } = makeClient({ wtFails: 'no WebTransport here' });
+    await connect(client, 'https://example.test:4433/wsh');
+
+    assert.deepEqual(attempted(log), ['wt', 'ws']);
+    // Both rungs get the *same* URL -- the WebSocket transport does its
+    // own https:// -> wss:// rewrite internally, and the ladder must not
+    // pre-empt it.
+    assert.equal(log[0].url, 'https://example.test:4433/wsh');
+    assert.equal(attempted(log).length, 2);
+    assert.equal(log.find((e) => e.kind === 'ws' && !e.closed).url, 'https://example.test:4433/wsh');
+  });
+
+  it('stops at WebTransport when it succeeds -- WebSocket is never constructed', async () => {
+    const { client, log } = makeClient();
+    await connect(client, 'https://example.test:4433/wsh');
+
+    assert.deepEqual(attempted(log), ['wt']);
+  });
+
+  it('a wss:// URL is WebSocket-only and never attempts WebTransport', async () => {
+    const { client, log } = makeClient();
+    await connect(client, 'wss://example.test:4433/wsh');
+
+    assert.deepEqual(attempted(log), ['ws']);
+  });
+
+  it('a ws:// URL is WebSocket-only too', async () => {
+    const { client, log } = makeClient();
+    await connect(client, 'ws://example.test:4433/wsh');
+
+    assert.deepEqual(attempted(log), ['ws']);
+  });
+
+  it('scheme matching is case-insensitive (WSS:// is still WebSocket-only)', async () => {
+    const { client, log } = makeClient();
+    await connect(client, 'WSS://example.test:4433/wsh');
+
+    assert.deepEqual(attempted(log), ['ws']);
+  });
+
+  it("transport: 'wt' forces WebTransport and does NOT fall back", async () => {
+    const { client, log } = makeClient({ wtFails: 'nope' });
+    await assert.rejects(
+      () => connect(client, 'https://example.test:4433/wsh', { transport: 'wt' }),
+      /Connection failed across transports.*wt: nope/s
+    );
+    assert.deepEqual(attempted(log), ['wt']);
+  });
+
+  it("transport: 'ws' forces WebSocket even for an https:// URL that would otherwise try wt first", async () => {
+    const { client, log } = makeClient();
+    await connect(client, 'https://example.test:4433/wsh', { transport: 'ws' });
+
+    assert.deepEqual(attempted(log), ['ws']);
+  });
+
+  it("transport: 'ws' overrides the wss:// rule's outcome identically (still ws-only)", async () => {
+    const { client, log } = makeClient();
+    await connect(client, 'wss://example.test:4433/wsh', { transport: 'ws' });
+
+    assert.deepEqual(attempted(log), ['ws']);
+  });
+
+  it('when every rung fails, the error names each rung and its reason', async () => {
+    const { client, log } = makeClient({ wtFails: 'h3 unreachable', wsFails: 'handshake refused' });
+    await assert.rejects(
+      () => connect(client, 'https://example.test:4433/wsh'),
+      (err) => {
+        assert.match(err.message, /wt: h3 unreachable/);
+        assert.match(err.message, /ws: handshake refused/);
+        return true;
+      }
+    );
+    assert.deepEqual(attempted(log), ['wt', 'ws']);
+  });
+
+  it('a failed rung is closed before the next one is tried, so nothing is left dangling', async () => {
+    const { client, log } = makeClient({ wtFails: 'nope' });
+    await connect(client, 'https://example.test:4433/wsh');
+
+    const wtClosed = log.findIndex((e) => e.kind === 'wt' && e.closed);
+    const wsAttempt = log.findIndex((e) => e.kind === 'ws' && !e.closed);
+    assert.ok(wtClosed !== -1, 'the failed wt transport must be closed');
+    assert.ok(wtClosed < wsAttempt, 'it must be closed before ws is attempted');
+  });
+
+  it('webTransport options reach the wt rung and are withheld from the ws rung', async () => {
+    const hashes = [{ algorithm: 'sha-256', value: new Uint8Array(32).fill(9) }];
+    const { client, log } = makeClient({ wtFails: 'nope' });
+    await connect(client, 'https://example.test:4433/wsh', {
+      webTransport: { serverCertificateHashes: hashes },
+    });
+
+    const wt = log.find((e) => e.kind === 'wt' && !e.closed);
+    const ws = log.find((e) => e.kind === 'ws' && !e.closed);
+    assert.deepEqual(wt.options, { serverCertificateHashes: hashes });
+    // A pinned certificate digest has no WebSocket equivalent; handing it
+    // to the fallback rung would imply a guarantee that rung cannot make.
+    assert.equal(ws.options, undefined);
+  });
+
+  it("transport: 'auto' is the explicit spelling of the default ladder", async () => {
+    const { client, log } = makeClient({ wtFails: 'nope' });
+    await connect(client, 'https://example.test:4433/wsh', { transport: 'auto' });
+
+    assert.deepEqual(attempted(log), ['wt', 'ws']);
+  });
+
+  it('a typo in the transport hint is rejected rather than silently downgrading to the ladder', async () => {
+    const { client, log } = makeClient();
+    await assert.rejects(
+      () => connect(client, 'https://example.test:4433/wsh', { transport: 'webtransport' }),
+      /Unknown transport hint: "webtransport"/
+    );
+    // The point is not the message: silently treating it as 'auto' would
+    // have connected over WebSocket, dropping any certificate pin the
+    // caller passed alongside it.
+    assert.deepEqual(attempted(log), []);
+  });
+});

--- a/test/transport-teardown.test.mjs
+++ b/test/transport-teardown.test.mjs
@@ -1,0 +1,159 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { WshTransport } from '../src/transport.mjs';
+import { WebSocketTransport } from '../src/transport-ws.mjs';
+
+// Two failure modes on the teardown path, both of which leave a live
+// connection behind. Neither is reachable through a mock server: what
+// goes wrong is between the transport and the socket underneath it.
+
+describe('WshTransport cleans up after a failed connect', () => {
+  /** Fails partway through _doConnect, after "acquiring" a resource. */
+  class HalfOpenTransport extends WshTransport {
+    acquired = false;
+    released = false;
+
+    async _doConnect() {
+      this.acquired = true;      // e.g. the WebSocket is now open
+      throw new Error('handshake failed after the socket opened');
+    }
+
+    async _doClose() {
+      this.released = true;
+    }
+
+    async _doSendControl() {}
+    async _doOpenStream() { throw new Error('unused'); }
+  }
+
+  it('_doClose() runs when _doConnect() throws, so a half-open resource is released', async () => {
+    const t = new HalfOpenTransport();
+    await assert.rejects(() => t.connect('wss://example.test/wsh'));
+
+    assert.equal(t.acquired, true);
+    assert.equal(t.released, true, 'the half-open transport must be torn down');
+    assert.equal(t.state, 'closed');
+  });
+
+  it('a later close() is still a safe no-op and does not tear down twice', async () => {
+    const t = new HalfOpenTransport();
+    await assert.rejects(() => t.connect('wss://example.test/wsh'));
+    t.released = false;
+
+    await t.close();
+    assert.equal(t.released, false, 'close() after a failed connect must not re-enter _doClose()');
+  });
+
+  it('does not emit onClose for a connection that never opened', async () => {
+    const t = new HalfOpenTransport();
+    let closeEvents = 0;
+    t.onClose = () => { closeEvents++; };
+
+    await assert.rejects(() => t.connect('wss://example.test/wsh'));
+    assert.equal(closeEvents, 0);
+  });
+
+  it('a _doClose() that throws does not mask the connect error', async () => {
+    class Nasty extends HalfOpenTransport {
+      async _doClose() { throw new Error('teardown also exploded'); }
+    }
+    const t = new Nasty();
+    await assert.rejects(
+      () => t.connect('wss://example.test/wsh'),
+      /handshake failed after the socket opened/
+    );
+  });
+});
+
+describe('WebSocketTransport teardown survives a broken socket', () => {
+  /**
+   * A socket that opens and then throws on every send. That is not an
+   * exotic case: a socket you cannot write to is the single most likely
+   * reason you are closing in the first place, and the graceful QMux
+   * CONNECTION_CLOSE that `_doClose()` sends is a write.
+   */
+  class UnwritableWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    static instances = [];
+
+    readyState = UnwritableWebSocket.CONNECTING;
+    binaryType = '';
+    closeCalls = [];
+    #listeners = new Map();
+
+    constructor(url) {
+      this.url = url;
+      UnwritableWebSocket.instances.push(this);
+      setTimeout(() => {
+        this.readyState = UnwritableWebSocket.OPEN;
+        for (const h of this.#listeners.get('open') || []) h();
+      }, 0);
+    }
+
+    addEventListener(type, handler) {
+      if (!this.#listeners.has(type)) this.#listeners.set(type, []);
+      this.#listeners.get(type).push(handler);
+    }
+
+    send() {
+      throw new Error('socket is broken');
+    }
+
+    close(code, reason) {
+      this.closeCalls.push([code, reason]);
+      this.readyState = UnwritableWebSocket.CLOSED;
+    }
+  }
+
+  let savedWebSocket;
+
+  beforeEach(() => {
+    savedWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = UnwritableWebSocket;
+    UnwritableWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    if (savedWebSocket === undefined) delete globalThis.WebSocket;
+    else globalThis.WebSocket = savedWebSocket;
+  });
+
+  it('closes the underlying socket even though the graceful CONNECTION_CLOSE write throws', async () => {
+    const t = new WebSocketTransport();
+    await assert.rejects(() => t.connect('wss://example.test/wsh'));
+
+    const socket = UnwritableWebSocket.instances[0];
+    assert.deepEqual(
+      socket.closeCalls,
+      [[1000, 'client close']],
+      'the socket must be closed, not leaked, when the courtesy close frame fails to send'
+    );
+    assert.equal(socket.readyState, UnwritableWebSocket.CLOSED);
+  });
+
+  it('close() on a connected-then-broken transport still closes the socket', async () => {
+    // Reach `connected` with a socket that only breaks afterwards.
+    let broken = false;
+    class BreaksLater extends UnwritableWebSocket {
+      send(data) {
+        if (broken) throw new Error('socket is broken');
+        // Swallow: the peer is not modelled here, only the socket.
+        void data;
+      }
+    }
+    globalThis.WebSocket = BreaksLater;
+
+    const t = new WebSocketTransport();
+    await t.connect('wss://example.test/wsh');
+    assert.equal(t.state, 'connected');
+
+    broken = true;
+    await t.close();
+
+    const socket = UnwritableWebSocket.instances[0];
+    assert.deepEqual(socket.closeCalls, [[1000, 'client close']]);
+  });
+});

--- a/test/transport-webtransport.test.mjs
+++ b/test/transport-webtransport.test.mjs
@@ -1,0 +1,209 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  WebTransportTransport,
+  parseCertificateHash,
+  normalizeWebTransportOptions,
+} from '../src/transport.mjs';
+
+// These tests stand in a real `WebTransport` global. That is a mock of
+// the *platform*, not of a wsh server: every assertion below is against
+// the WebTransport constructor's own contract (what arguments it is
+// handed), which no counterparty can answer differently to make the
+// client happy. The thing being checked is precisely the thing a mocked
+// server could never reveal -- that the options a caller asked for
+// actually reach the browser API.
+
+/** A stand-in WebTransport that records exactly how it was constructed. */
+class FakeWebTransport {
+  static calls = [];
+
+  constructor(url, options) {
+    // Record `arguments.length` too: `new WebTransport(url)` and
+    // `new WebTransport(url, {})` are equivalent to the platform but not
+    // to this test -- the second form is what a naive `{...undefined}`
+    // spread would produce, and it would hide a dropped option.
+    FakeWebTransport.calls.push({ url, options, argCount: arguments.length });
+
+    this.ready = Promise.resolve();
+    this.closed = new Promise(() => {});
+  }
+
+  createBidirectionalStream() {
+    return Promise.resolve({
+      readable: new ReadableStream({ start(c) { c.close(); } }),
+      writable: new WritableStream(),
+    });
+  }
+
+  get incomingBidirectionalStreams() {
+    return new ReadableStream({ start(c) { c.close(); } });
+  }
+
+  close() {}
+}
+
+let savedWebTransport;
+
+beforeEach(() => {
+  savedWebTransport = globalThis.WebTransport;
+  globalThis.WebTransport = FakeWebTransport;
+  FakeWebTransport.calls = [];
+});
+
+afterEach(() => {
+  if (savedWebTransport === undefined) delete globalThis.WebTransport;
+  else globalThis.WebTransport = savedWebTransport;
+});
+
+// A real SHA-256 digest of a certificate, in the three shapes a caller
+// plausibly has it in.
+const HASH_HEX = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const HASH_BYTES = Uint8Array.from(
+  HASH_HEX.match(/../g).map((h) => Number.parseInt(h, 16))
+);
+const HASH_B64 = Buffer.from(HASH_BYTES).toString('base64');
+
+describe('parseCertificateHash', () => {
+  it('accepts plain hex', () => {
+    assert.deepEqual(parseCertificateHash(HASH_HEX), HASH_BYTES);
+  });
+
+  it('accepts the colon-separated hex openssl prints', () => {
+    const colons = HASH_HEX.match(/../g).join(':').toUpperCase();
+    assert.deepEqual(parseCertificateHash(colons), HASH_BYTES);
+  });
+
+  it("accepts openssl's full `SHA256 Fingerprint=AB:CD:...` line", () => {
+    const line = `SHA256 Fingerprint=${HASH_HEX.match(/../g).join(':').toUpperCase()}`;
+    assert.deepEqual(parseCertificateHash(line), HASH_BYTES);
+  });
+
+  it('accepts base64 and base64url', () => {
+    assert.deepEqual(parseCertificateHash(HASH_B64), HASH_BYTES);
+    const b64url = HASH_B64.replace(/\+/g, '-').replace(/\//g, '_');
+    assert.deepEqual(parseCertificateHash(b64url), HASH_BYTES);
+  });
+
+  it('passes a BufferSource straight through as bytes', () => {
+    assert.deepEqual(parseCertificateHash(HASH_BYTES), HASH_BYTES);
+    assert.deepEqual(parseCertificateHash(HASH_BYTES.buffer), HASH_BYTES);
+  });
+
+  it('rejects a digest of the wrong length rather than letting the connection fail opaquely', () => {
+    assert.throws(
+      () => parseCertificateHash('0123456789abcdef'),
+      (err) => err instanceof RangeError && /32 bytes, got 8/.test(err.message)
+    );
+  });
+
+  it('rejects a string that is neither hex nor base64', () => {
+    assert.throws(() => parseCertificateHash('not a digest!!'), TypeError);
+  });
+
+  it('rejects a non-string, non-BufferSource value', () => {
+    assert.throws(() => parseCertificateHash(12345), TypeError);
+  });
+});
+
+describe('normalizeWebTransportOptions', () => {
+  it('returns undefined when there is nothing to pass', () => {
+    assert.equal(normalizeWebTransportOptions(undefined), undefined);
+    assert.equal(normalizeWebTransportOptions({}), undefined);
+    assert.equal(normalizeWebTransportOptions({ congestionControl: undefined }), undefined);
+  });
+
+  it('normalizes every accepted digest shape to { algorithm, value: Uint8Array }', () => {
+    const out = normalizeWebTransportOptions({
+      serverCertificateHashes: [
+        HASH_HEX,
+        HASH_BYTES,
+        { value: HASH_B64 },
+        { algorithm: 'SHA-256', value: HASH_HEX },
+      ],
+    });
+    assert.equal(out.serverCertificateHashes.length, 4);
+    for (const entry of out.serverCertificateHashes) {
+      assert.equal(entry.algorithm, 'sha-256');
+      assert.ok(entry.value instanceof Uint8Array);
+      assert.deepEqual(entry.value, HASH_BYTES);
+    }
+  });
+
+  it('forwards unknown platform options verbatim', () => {
+    const out = normalizeWebTransportOptions({
+      congestionControl: 'low-latency',
+      requireUnreliable: true,
+      somethingTheEngineGainsLater: 42,
+    });
+    assert.deepEqual(out, {
+      congestionControl: 'low-latency',
+      requireUnreliable: true,
+      somethingTheEngineGainsLater: 42,
+    });
+  });
+
+  it('rejects an empty or non-array serverCertificateHashes', () => {
+    assert.throws(() => normalizeWebTransportOptions({ serverCertificateHashes: [] }), TypeError);
+    assert.throws(() => normalizeWebTransportOptions({ serverCertificateHashes: HASH_HEX }), TypeError);
+  });
+});
+
+describe('WebTransportTransport passes options to the WebTransport constructor', () => {
+  it('serverCertificateHashes given to the constructor reaches `new WebTransport(url, options)`', async () => {
+    const t = new WebTransportTransport({ serverCertificateHashes: [HASH_HEX] });
+    await t.connect('https://192.168.1.20:4433/wsh');
+
+    assert.equal(FakeWebTransport.calls.length, 1);
+    const call = FakeWebTransport.calls[0];
+    assert.equal(call.url, 'https://192.168.1.20:4433/wsh');
+    assert.equal(call.argCount, 2, 'the options dictionary must actually be passed');
+    assert.deepEqual(call.options, {
+      serverCertificateHashes: [{ algorithm: 'sha-256', value: HASH_BYTES }],
+    });
+  });
+
+  it('options given to connect() reach the constructor too', async () => {
+    const t = new WebTransportTransport();
+    await t.connect('https://example.test:4433/wsh', {
+      serverCertificateHashes: [{ algorithm: 'sha-256', value: HASH_BYTES }],
+    });
+
+    assert.equal(FakeWebTransport.calls[0].argCount, 2);
+    assert.deepEqual(FakeWebTransport.calls[0].options.serverCertificateHashes, [
+      { algorithm: 'sha-256', value: HASH_BYTES },
+    ]);
+  });
+
+  it('connect() options override constructor options key by key', async () => {
+    const other = new Uint8Array(32).fill(0xaa);
+    const t = new WebTransportTransport({
+      serverCertificateHashes: [HASH_HEX],
+      congestionControl: 'throughput',
+    });
+    await t.connect('https://example.test:4433/wsh', { serverCertificateHashes: [other] });
+
+    assert.deepEqual(FakeWebTransport.calls[0].options, {
+      serverCertificateHashes: [{ algorithm: 'sha-256', value: other }],
+      congestionControl: 'throughput',
+    });
+  });
+
+  it('passes no second argument at all when no options were given', async () => {
+    const t = new WebTransportTransport();
+    await t.connect('https://example.test:4433/wsh');
+
+    assert.equal(FakeWebTransport.calls[0].argCount, 1);
+    assert.equal(FakeWebTransport.calls[0].options, undefined);
+  });
+
+  it('a malformed hash fails the connect locally, before any network work', async () => {
+    const t = new WebTransportTransport({ serverCertificateHashes: ['deadbeef'] });
+    await assert.rejects(
+      () => t.connect('https://example.test:4433/wsh'),
+      RangeError
+    );
+    assert.equal(FakeWebTransport.calls.length, 0, 'must not have constructed a WebTransport');
+    assert.equal(t.state, 'closed');
+  });
+});


### PR DESCRIPTION
Five changes, each with a test that fails without it. `npm test` goes 443 → 525 passing,
zero failures.

## `serverCertificateHashes` could not be passed at all

`transport.mjs` called `new WebTransport(url)` with no options object, so
`serverCertificateHashes` — the one web-platform mechanism that lets page JavaScript pin a
short-lived self-signed certificate — was unreachable. That matters for any LAN peer: it is
the only way to reach a self-signed server from a secure origin without a native plugin.

The evidence that this is needed came from downstream: a consumer works around it by
subclassing `WebTransport` to inject the hashes before constructing. A passthrough removes
the need for that.

## A failed connect left its socket open

If the connection attempt threw after the socket was created, nothing closed it, and a
socket that broke during teardown skipped the rest of its own cleanup. Both leak.

## The transport ladder had no test

`#buildTransportAttempts` decides WebTransport-vs-WebSocket and the fallback between them —
arguably the most load-bearing behaviour in the client — and nothing covered it. Now covered,
including that a typo'd transport hint is rejected rather than silently ignored.

## CBOR `null` for required wire fields

The client sent `null` where the spec requires a value. Now tested against the spec rather
than against the client's own expectations.

## The Ed25519 floor is now stated, and detectable

`generateKeyPair` calls `crypto.subtle` directly with no fallback, so below the WebCrypto
floor it throws rather than degrades. Rather than add a polyfill dependency, this documents
the floor and adds `isEd25519Supported()` so a caller can branch before it throws.

Measured, and worth recording because the ecosystem assumes the opposite: **WebTransport is
present and complete in WebKit on iOS 26.5** — 17 prototype members including datagrams,
getStats and createSendGroup — versus 10 in Chromium 148. WebKit is ahead here. ML-KEM-768
fails on both.


---

Closes #26. Closes #27. Closes #28. Closes #29. Closes #30.
