### PR TITLE
Make WshMcpBridge and WshFileTransfer work with the WshClient they document, and stop leaking an onControl wrapper per operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## Unreleased
+
+- **Fix: `WshMcpBridge` and `WshFileTransfer.list()` were unreachable from a
+  `WshClient`.** Both classes are exported from the package root and both
+  document their constructor argument as "a WshClient", and both drive the
+  connection through `sendControl()` plus `addControlListener()` /
+  `removeControlListener()` (`list()` also needs `openStream()`). `WshClient`
+  exposed none of those, so `discover()`, `call()` and `list()` all failed
+  immediately with
+
+  ```
+  TypeError: this.#client.sendControl is not a function
+  ```
+
+  the first time a real client reached them. Three public methods
+  unreachable while the suite was green — the same shape as 0.14.0's
+  `attachSession()`/`resumeSession()`, and for the same reason: every test
+  and both examples passed a hand-written stand-in, and a stand-in written
+  to satisfy the caller cannot disagree with it.
+
+  `WshClient` gains `sendControl()`, `openStream()`, `addControlListener()`
+  and `removeControlListener()` — thin delegations to the transport it
+  already owns and to `#handleControl`, which already sees every inbound
+  control message. Listeners are dispatched *after* the RelayForward trust
+  gate, so a relayed message from a peer this client has not accepted never
+  reaches one, and a trusted RelayForward arrives unwrapped.
+
+- **Fix: each bridge operation leaked a permanent `onControl` wrapper.** For
+  a client whose only hook is a settable `onControl` property — which is what
+  a bare `WshTransport` is — the subscription inlined in both helpers wrapped
+  that property and never unwrapped it; the matching `cleanup()` handled only
+  `removeControlListener` and `_controlListeners`. Measured against a real
+  `WshTransport`, the frames an inbound control message traversed to reach the
+  connection's own handler grew one per operation, with no ceiling: 1, 5, 20
+  and 50 operations gave 5, 9, 24 and 54. Subscription now lives in
+  `src/control-listener.mjs`, attaches once and detaches on cleanup, and
+  restores the displaced handler only while its own wrapper is still the
+  installed one — putting `prev` back unconditionally severs any subscription
+  that nested inside it.
+
+- **`WshMcpBridge`'s constructor and `WshFileTransfer.list()` now reject a
+  client that cannot work**, naming the missing member, instead of failing
+  later with a `TypeError` about a private field. `WshFileTransfer`'s
+  constructor is unchanged: `upload()`/`download()` need nothing from the
+  control channel.
+
+- `WshFileTransfer`'s control-message timeout text changed from
+  `Timeout waiting for response (30000ms)` to
+  `File transfer response timed out after 30000ms`.
+
+- New `test/helpers-against-real-client.test.mjs`: every case drives a real
+  `WshClient` over a real `WshTransport` subclass through the real handshake,
+  and asserts on what reached the wire. `npm test` goes 443 → 453.
+
 ## 0.14.0
 
 - **Fix: `attachSession()`/`resumeSession()` were both unreachable** (clawser

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -181,6 +181,13 @@ export class WshClient {
    */
   #acceptedRelayPeers = new Set();
 
+  /**
+   * Observers registered through addControlListener() — see that method
+   * and #dispatchControlListeners.
+   * @type {Set<function(object): void>}
+   */
+  #controlListeners = new Set();
+
   /** @type {number} Monotonically increasing channel ID counter. */
   #channelCounter = 0;
 
@@ -983,6 +990,71 @@ export class WshClient {
   async sendRelayControl(msg) {
     this.#assertAuthenticated('sendRelayControl');
     await this.#transport.sendControl(msg);
+  }
+
+  // ── Raw control channel (used by WshMcpBridge / WshFileTransfer) ─────
+  //
+  // `WshMcpBridge` and `WshFileTransfer` both document their constructor
+  // argument as "a WshClient", and both drive the connection through
+  // `sendControl()` + `addControlListener()`/`removeControlListener()`
+  // (`WshFileTransfer.list()` also needs `openStream()`). None of those
+  // existed on this class, so every one of those code paths failed with
+  // `TypeError: this.#client.sendControl is not a function` the moment a
+  // real client was passed instead of a hand-written stand-in — the same
+  // shape as the 0.14.0 `attachSession()`/`resumeSession()` bug, where a
+  // whole method was unreachable while the suite stayed green because
+  // every test spoke to a mock that answered whatever it was asked.
+  //
+  // These four members are thin, deliberate delegations rather than a new
+  // subsystem: the transport already owns the socket and the framing, and
+  // `#handleControl` already sees every inbound control message.
+
+  /**
+   * Send a raw control message on the authenticated connection.
+   *
+   * Prefer the typed methods (`openSession`, `callTool`, `upload`, …).
+   * This exists for the helper classes that compose their own messages —
+   * see `WshMcpBridge` and `WshFileTransfer`.
+   *
+   * @param {object} msg
+   * @returns {Promise<void>}
+   */
+  async sendControl(msg) {
+    this.#assertAuthenticated('sendControl');
+    await this.#transport.sendControl(msg);
+  }
+
+  /**
+   * Open a raw bidirectional stream on the underlying transport.
+   *
+   * @returns {Promise<{ readable: ReadableStream, writable: WritableStream }>}
+   */
+  async openStream() {
+    this.#assertAuthenticated('openStream');
+    return this.#transport.openStream();
+  }
+
+  /**
+   * Observe every inbound control message this client handles.
+   *
+   * Listeners are called after the RelayForward trust gate, so a relayed
+   * message from an untrusted peer is never handed to one, and a trusted
+   * RelayForward is delivered as its unwrapped inner message. A listener
+   * that throws is logged and does not stop the client's own dispatch.
+   *
+   * @param {function(object): void} fn
+   */
+  addControlListener(fn) {
+    if (typeof fn !== 'function') throw new TypeError('addControlListener requires a function');
+    this.#controlListeners.add(fn);
+  }
+
+  /**
+   * Stop observing inbound control messages.
+   * @param {function(object): void} fn
+   */
+  removeControlListener(fn) {
+    this.#controlListeners.delete(fn);
   }
 
   /**
@@ -1804,6 +1876,13 @@ export class WshClient {
       return;
     }
 
+    // Observers registered via addControlListener() see the message here —
+    // past the RelayForward trust gate above (so an untrusted peer's
+    // message never reaches one, and a trusted one arrives unwrapped) and
+    // before this client's own dispatch, so a helper waiting on a reply
+    // cannot miss it to an ordering accident.
+    this.#dispatchControlListeners(msg);
+
     // OPEN_OK/OPEN_FAIL: handled as a dedicated case (not the generic
     // waiter mechanism below) so the WshSession gets constructed and
     // registered in #sessions synchronously, in the same dispatch step as
@@ -2196,6 +2275,28 @@ export class WshClient {
   #assertAuthenticated(action) {
     if (this.#state !== STATE_AUTHENTICATED) {
       throw new Error(`Cannot ${action}: client is ${this.#state} (expected authenticated)`);
+    }
+  }
+
+  /**
+   * Hand a control message to every addControlListener() observer.
+   *
+   * Iterates a copy, so a listener that deregisters itself (the normal
+   * case — a one-shot reply waiter) does not perturb the iteration, and
+   * isolates throws so one bad observer cannot break the client's own
+   * dispatch of the same message.
+   *
+   * @param {object} msg
+   * @private
+   */
+  #dispatchControlListeners(msg) {
+    if (this.#controlListeners.size === 0) return;
+    for (const fn of [...this.#controlListeners]) {
+      try {
+        fn(msg);
+      } catch (err) {
+        console.error('[wsh:client] control listener error:', err);
+      }
     }
   }
 

--- a/src/control-listener.mjs
+++ b/src/control-listener.mjs
@@ -1,0 +1,130 @@
+/**
+ * Control-message subscription for the helper classes that compose their
+ * own wire messages — `WshMcpBridge` and `WshFileTransfer`.
+ *
+ * Both accept "a WshClient, or any object exposing sendControl() plus a
+ * way to observe inbound control messages", and both used to inline the
+ * same three-way registration. The third branch of it — the fallback for
+ * an object whose only hook is a settable `onControl` property, which is
+ * what a bare `WshTransport` is — wrapped that property and **never
+ * unwrapped it**:
+ *
+ * ```js
+ * const prev = client.onControl;
+ * client.onControl = (msg) => { prev?.(msg); listener(msg); };
+ * ```
+ *
+ * The matching `cleanup()` handled `removeControlListener` and
+ * `_controlListeners` and did nothing at all for this branch. So every
+ * `discover()` / `call()` / `list()` left another wrapper permanently in
+ * the chain. Measured against a real `WshTransport`, the number of frames
+ * an inbound control message traverses to reach the connection's own
+ * handler grew one-for-one with the number of operations — 1, 5, 20 and
+ * 50 operations gave 5, 9, 24 and 54 frames — with no ceiling.
+ *
+ * Attaching once per subscriber and detaching on cleanup keeps that flat.
+ */
+
+/**
+ * Subscribe `listener` to a client's inbound control messages.
+ *
+ * Supports, in order of preference:
+ *  1. `addControlListener()` / `removeControlListener()` — what `WshClient`
+ *     exposes, and the only shape that can deregister cleanly.
+ *  2. A `_controlListeners` array.
+ *  3. A settable `onControl` property (a bare `WshTransport`), wrapped
+ *     once and restored on detach.
+ *
+ * @param {object} client
+ * @param {function(object): void} listener
+ * @returns {function(): void} detach — idempotent; safe to call twice.
+ */
+export function attachControlListener(client, listener) {
+  if (typeof client.addControlListener === 'function') {
+    client.addControlListener(listener);
+    let detached = false;
+    return () => {
+      if (detached) return;
+      detached = true;
+      client.removeControlListener?.(listener);
+    };
+  }
+
+  if (Array.isArray(client._controlListeners)) {
+    client._controlListeners.push(listener);
+    let detached = false;
+    return () => {
+      if (detached) return;
+      detached = true;
+      const idx = client._controlListeners.indexOf(listener);
+      if (idx !== -1) client._controlListeners.splice(idx, 1);
+    };
+  }
+
+  // Fallback: wrap `onControl`. Restoring `prev` is only correct while our
+  // wrapper is still the installed handler — if something else has wrapped
+  // it since, putting `prev` back would drop that handler. In that case the
+  // wrapper stays but is made inert, so the chain stops growing per
+  // operation even though this one link cannot be spliced out.
+  const prev = client.onControl;
+  let live = true;
+  const wrapper = (msg) => {
+    prev?.(msg);
+    if (live) listener(msg);
+  };
+  client.onControl = wrapper;
+
+  let detached = false;
+  return () => {
+    if (detached) return;
+    detached = true;
+    live = false;
+    if (client.onControl === wrapper) client.onControl = prev;
+  };
+}
+
+/**
+ * Wait for the first inbound control message matching `predicate`.
+ *
+ * @param {object} client
+ * @param {function(object): boolean} predicate
+ * @param {number} timeoutMs
+ * @param {string} label - Used in the timeout message.
+ * @returns {Promise<object>}
+ */
+export function waitForControlMessage(client, predicate, timeoutMs, label) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let detach = () => {};
+    let timer = null;
+
+    const cleanup = () => {
+      settled = true;
+      if (timer !== null) clearTimeout(timer);
+      detach();
+    };
+
+    // `detach` is assigned after attach() returns, but a client that
+    // dispatches synchronously from inside attach() would fire the
+    // listener first — hence the `settled` guard rather than relying on
+    // detach() having been wired up.
+    detach = attachControlListener(client, (msg) => {
+      if (settled) return;
+      let matches = false;
+      try {
+        matches = predicate(msg);
+      } catch {
+        matches = false;
+      }
+      if (!matches) return;
+      cleanup();
+      resolve(msg);
+    });
+
+    timer = setTimeout(() => {
+      if (settled) return;
+      cleanup();
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+}

--- a/src/file-transfer.mjs
+++ b/src/file-transfer.mjs
@@ -8,6 +8,7 @@
  */
 
 import { MSG, open, CHANNEL_KIND } from './messages.mjs';
+import { waitForControlMessage } from './control-listener.mjs';
 
 /** Default timeout for waiting on control messages (30 seconds). */
 const RESPONSE_TIMEOUT_MS = 30_000;
@@ -30,6 +31,10 @@ export class WshFileTransfer {
    *   - openStream(): open a new bidirectional stream
    *   - onControl: settable callback for incoming control messages
    *     (or a method to add a listener — see _waitForMessage)
+   *
+   *   Only `list()` needs the control-channel members, so they are checked
+   *   there rather than here: uploading and downloading through a client
+   *   that has `upload()`/`download()` and nothing else stays valid.
    */
   constructor(client) {
     if (!client) throw new Error('WshFileTransfer requires a client');
@@ -104,6 +109,11 @@ export class WshFileTransfer {
     if (!remotePath || typeof remotePath !== 'string') {
       throw new Error('remotePath is required');
     }
+    if (typeof this.#client.sendControl !== 'function' || typeof this.#client.openStream !== 'function') {
+      throw new TypeError(
+        'WshFileTransfer.list() requires a client exposing sendControl() and openStream() (e.g. WshClient)'
+      );
+    }
 
     // Use an exec channel to run ls
     const openMsg = open({
@@ -154,51 +164,7 @@ export class WshFileTransfer {
    * @returns {Promise<object>}
    */
   _waitForMessage(predicate, timeoutMs) {
-    return new Promise((resolve, reject) => {
-      let timer = null;
-      let settled = false;
-
-      const cleanup = () => {
-        settled = true;
-        if (timer !== null) clearTimeout(timer);
-        // Remove listener
-        if (this.#client.removeControlListener) {
-          this.#client.removeControlListener(listener);
-        } else if (this.#client._controlListeners) {
-          const idx = this.#client._controlListeners.indexOf(listener);
-          if (idx !== -1) this.#client._controlListeners.splice(idx, 1);
-        }
-      };
-
-      const listener = (msg) => {
-        if (settled) return;
-        if (predicate(msg)) {
-          cleanup();
-          resolve(msg);
-        }
-      };
-
-      // Register listener on the client
-      if (this.#client.addControlListener) {
-        this.#client.addControlListener(listener);
-      } else if (this.#client._controlListeners) {
-        this.#client._controlListeners.push(listener);
-      } else {
-        // Fallback: wrap existing onControl
-        const prev = this.#client.onControl;
-        this.#client.onControl = (msg) => {
-          prev?.(msg);
-          listener(msg);
-        };
-      }
-
-      timer = setTimeout(() => {
-        if (!settled) {
-          cleanup();
-          reject(new Error(`Timeout waiting for response (${timeoutMs}ms)`));
-        }
-      }, timeoutMs);
-    });
+    return waitForControlMessage(this.#client, predicate, timeoutMs, 'File transfer response');
   }
 
   /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1698,6 +1698,31 @@ export class WshClient {
   sendRelayControl(msg: WshMessage): Promise<void>;
 
   /**
+   * Send a raw control message on the authenticated connection.
+   *
+   * Prefer the typed methods. This is the hook `WshMcpBridge` and
+   * `WshFileTransfer` compose their own messages through.
+   */
+  sendControl(msg: WshMessage): Promise<void>;
+
+  /**
+   * Open a raw bidirectional stream on the underlying transport.
+   */
+  openStream(): Promise<WshStream>;
+
+  /**
+   * Observe every inbound control message this client handles. Listeners
+   * are called past the RelayForward trust gate, so a message from an
+   * unaccepted peer never reaches one.
+   */
+  addControlListener(fn: (msg: WshMessage) => void): void;
+
+  /**
+   * Stop observing inbound control messages.
+   */
+  removeControlListener(fn: (msg: WshMessage) => void): void;
+
+  /**
    * Initiate end-to-end encryption for a session: `'X25519'` (default,
    * classical ECDH) or `'X25519+ML-KEM-768'` (hybrid, with automatic
    * fallback to classical if the peer doesn't support it). Experimental

--- a/src/mcp-bridge.mjs
+++ b/src/mcp-bridge.mjs
@@ -7,6 +7,7 @@
  */
 
 import { MSG, mcpDiscover, mcpCall } from './messages.mjs';
+import { waitForControlMessage } from './control-listener.mjs';
 
 /** Default timeout for MCP operations (15 seconds). */
 const MCP_TIMEOUT_MS = 15_000;
@@ -19,13 +20,24 @@ export class WshMcpBridge {
   #tools = new Map();
 
   /**
-   * @param {object} client - A WshClient or transport exposing:
+   * @param {object} client - A `WshClient`, a `WshTransport`, or any object
+   *   exposing:
    *   - sendControl(msg): send a control message
    *   - addControlListener(fn) / removeControlListener(fn): message listeners
-   *     (or _controlListeners array, or onControl callback)
+   *     (or a `_controlListeners` array, or a settable `onControl` callback)
+   *
+   *   `sendControl` is checked here rather than at first use: without it
+   *   `discover()` failed with `TypeError: this.#client.sendControl is not
+   *   a function` from inside a promise, naming a private field and not
+   *   the argument that was actually wrong.
    */
   constructor(client) {
     if (!client) throw new Error('WshMcpBridge requires a client');
+    if (typeof client.sendControl !== 'function') {
+      throw new TypeError(
+        'WshMcpBridge requires a client exposing sendControl() — pass a WshClient or a WshTransport'
+      );
+    }
     this.#client = client;
   }
 
@@ -171,58 +183,17 @@ export class WshMcpBridge {
   /**
    * Wait for a control message matching a predicate.
    *
-   * Temporarily hooks into the client's control message flow and resolves
-   * when a matching message arrives (or rejects on timeout).
+   * Subscribes to the client's control message flow and resolves when a
+   * matching message arrives (or rejects on timeout). Deregistration is
+   * `control-listener.mjs`'s job — the version inlined here leaked one
+   * permanent `onControl` wrapper per operation against any client whose
+   * only hook is that property.
    *
    * @param {function(object): boolean} predicate
    * @param {number} timeoutMs
    * @returns {Promise<object>}
    */
   _waitForMessage(predicate, timeoutMs) {
-    return new Promise((resolve, reject) => {
-      let timer = null;
-      let settled = false;
-
-      const cleanup = () => {
-        settled = true;
-        if (timer !== null) clearTimeout(timer);
-        // Remove listener
-        if (this.#client.removeControlListener) {
-          this.#client.removeControlListener(listener);
-        } else if (this.#client._controlListeners) {
-          const idx = this.#client._controlListeners.indexOf(listener);
-          if (idx !== -1) this.#client._controlListeners.splice(idx, 1);
-        }
-      };
-
-      const listener = (msg) => {
-        if (settled) return;
-        if (predicate(msg)) {
-          cleanup();
-          resolve(msg);
-        }
-      };
-
-      // Register listener on the client
-      if (this.#client.addControlListener) {
-        this.#client.addControlListener(listener);
-      } else if (this.#client._controlListeners) {
-        this.#client._controlListeners.push(listener);
-      } else {
-        // Fallback: wrap existing onControl
-        const prev = this.#client.onControl;
-        this.#client.onControl = (msg) => {
-          prev?.(msg);
-          listener(msg);
-        };
-      }
-
-      timer = setTimeout(() => {
-        if (!settled) {
-          cleanup();
-          reject(new Error(`MCP operation timed out after ${timeoutMs}ms`));
-        }
-      }, timeoutMs);
-    });
+    return waitForControlMessage(this.#client, predicate, timeoutMs, 'MCP operation');
   }
 }

--- a/test/helpers-against-real-client.test.mjs
+++ b/test/helpers-against-real-client.test.mjs
@@ -1,0 +1,305 @@
+// test/helpers-against-real-client.test.mjs
+//
+// `WshMcpBridge` and `WshFileTransfer` are exported from the package root
+// and both document their constructor argument as "a WshClient". Neither
+// had ever been handed one: every existing test and both examples build a
+// bespoke stand-in — `{ sendControl, addControlListener, removeControlListener }`
+// in examples/05, `{ sendControl: async () => {}, openStream: async () => ({}) }`
+// at test/file-transfer.test.mjs:297 — and a stand-in written to satisfy
+// the caller cannot disagree with it.
+//
+// A real `WshClient` exposed none of those members. `WshMcpBridge.discover()`,
+// `WshMcpBridge.call()` and `WshFileTransfer.list()` therefore all died on
+//
+//     TypeError: this.#client.sendControl is not a function
+//
+// the first time a real client reached them — three public methods
+// unreachable while the suite was green, which is the shape CHANGELOG
+// 0.14.0 records for `attachSession()`/`resumeSession()`.
+//
+// So every test below drives a real `WshClient`, connected over a real
+// `WshTransport` subclass, through the real handshake. The server side is
+// in-process, but it is on the far side of the client — it never stands in
+// for the client itself.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { WshTransport } from '../src/transport.mjs';
+import { MSG, mcpTools, mcpResult, openOk } from '../src/messages.gen.mjs';
+import { WshMcpBridge } from '../src/mcp-bridge.mjs';
+import { WshFileTransfer } from '../src/file-transfer.mjs';
+import { attachControlListener } from '../src/control-listener.mjs';
+
+let auth;
+let clientMod;
+try {
+  auth = await import('../src/auth.mjs');
+  clientMod = await import('../src/client.mjs');
+} catch {
+  // Web Crypto Ed25519 unavailable in this runtime.
+}
+const hasEd25519 = auth && typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined';
+
+const LS_OUTPUT = [
+  'total 8',
+  'drwxr-xr-x  3 user  staff   96 Jan  1 10:00 .',
+  'drwxr-xr-x  5 user  staff  160 Jan  1 09:00 ..',
+  '-rw-r--r--  1 user  staff  512 Jan  2 11:30 notes.txt',
+  '',
+].join('\n');
+
+/**
+ * A transport with a small in-process server behind it: it completes the
+ * auth handshake, and answers MCP_DISCOVER / MCP_CALL / OPEN the way the
+ * protocol says a server does. Replies land on a macrotask, as they would
+ * off a socket — replying on a microtask can beat the caller's own
+ * response-waiter registration and be dropped (see the note on
+ * ChallengeFirstMockTransport in client.test.mjs).
+ */
+class ServerBackedTransport extends WshTransport {
+  /** Every message the client actually put on the wire. */
+  sent = [];
+
+  async _doConnect() {}
+  async _doClose() {}
+
+  async _doSendControl(msg) {
+    this.sent.push(msg);
+    const reply = (m) => setTimeout(() => this._emitControl(m), 0);
+
+    if (msg.type === MSG.HELLO) {
+      reply({ type: MSG.CHALLENGE, nonce: new Uint8Array(32).fill(7), session_id: 'sess-helpers' });
+    } else if (msg.type === MSG.AUTH) {
+      reply({ type: MSG.AUTH_OK });
+    } else if (msg.type === MSG.MCP_DISCOVER) {
+      reply(mcpTools({
+        tools: [
+          { name: 'read_file', description: 'Read a file', parameters: { type: 'object' } },
+          { name: 'ping', description: 'No arguments at all', parameters: { type: 'object' } },
+        ],
+      }));
+    } else if (msg.type === MSG.MCP_CALL) {
+      reply(mcpResult({ result: { success: true, output: `called ${msg.tool}` } }));
+    } else if (msg.type === MSG.OPEN) {
+      reply(openOk({ channel_id: 1, stream_ids: {}, data_mode: 'stream', capabilities: [] }));
+    }
+  }
+
+  async _doOpenStream() {
+    return {
+      id: 1,
+      readable: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(LS_OUTPUT));
+          controller.close();
+        },
+      }),
+      writable: new WritableStream({ write() {} }),
+    };
+  }
+}
+
+async function connectRealClient(transport) {
+  const keyPair = await auth.generateKeyPair(true);
+  const client = new clientMod.WshClient({ transportFactories: { ws: () => transport } });
+  await client.connect('ws://test.invalid', { username: 'alice', keyPair, transport: 'ws' });
+  return client;
+}
+
+describe('helper classes against a real WshClient', { skip: !hasEd25519 && 'Ed25519 not available in this runtime' }, () => {
+  it('WshMcpBridge.discover() reaches the wire and returns the server\'s tools', async () => {
+    const transport = new ServerBackedTransport();
+    const client = await connectRealClient(transport);
+
+    const tools = await new WshMcpBridge(client).discover({ timeout: 2000 });
+
+    // The assertion that matters is not the return value — it is that a
+    // MCP_DISCOVER was actually put on the wire. Before the fix nothing
+    // ever left the client.
+    assert.equal(transport.sent.filter((m) => m.type === MSG.MCP_DISCOVER).length, 1);
+    assert.deepEqual(tools.map((t) => t.name), ['read_file', 'ping']);
+  });
+
+  it('WshMcpBridge.call() puts a complete McpCall on the wire and normalizes the reply', async () => {
+    const transport = new ServerBackedTransport();
+    const client = await connectRealClient(transport);
+    const bridge = new WshMcpBridge(client);
+    await bridge.discover({ timeout: 2000 });
+
+    const result = await bridge.call('read_file', { path: '/etc/hostname' }, { timeout: 2000 });
+
+    const call = transport.sent.find((m) => m.type === MSG.MCP_CALL);
+    assert.ok(call, 'no McpCall reached the transport');
+    assert.equal(call.tool, 'read_file');
+    // `arguments` is required: true in spec/wsh-v1.yaml, and `undefined`
+    // does not vanish — cborEncode emits the key with a CBOR null.
+    assert.deepEqual(call.arguments, { path: '/etc/hostname' });
+    assert.deepEqual(result, { success: true, output: 'called read_file', error: undefined });
+  });
+
+  it('WshMcpBridge.call() on a no-argument tool still sends an object, not null', async () => {
+    const transport = new ServerBackedTransport();
+    const client = await connectRealClient(transport);
+    const bridge = new WshMcpBridge(client);
+    await bridge.discover({ timeout: 2000 });
+
+    await bridge.call('ping', undefined, { timeout: 2000 });
+
+    const call = transport.sent.find((m) => m.type === MSG.MCP_CALL);
+    assert.deepEqual(call.arguments, {});
+    assert.notEqual(call.arguments, null);
+  });
+
+  it('WshFileTransfer.list() drives a real client end to end', async () => {
+    const transport = new ServerBackedTransport();
+    const client = await connectRealClient(transport);
+
+    const entries = await new WshFileTransfer(client).list('/home/alice');
+
+    const open = transport.sent.find((m) => m.type === MSG.OPEN);
+    assert.ok(open, 'no Open reached the transport');
+    assert.match(open.command, /^ls -la /);
+    assert.ok(entries.some((e) => e.name === 'notes.txt'), `parsed entries: ${JSON.stringify(entries)}`);
+  });
+
+  it('a client with no sendControl is refused by name, not by a TypeError on a private field', async () => {
+    assert.throws(
+      () => new WshMcpBridge({ discoverTools: async () => [] }),
+      (err) => err instanceof TypeError && /sendControl/.test(err.message),
+    );
+    await assert.rejects(
+      () => new WshFileTransfer({ upload: async () => {} }).list('/tmp'),
+      (err) => err instanceof TypeError && /sendControl\(\) and openStream\(\)/.test(err.message),
+    );
+  });
+
+  it('repeated bridge operations leave no listeners behind on the client', async () => {
+    const transport = new ServerBackedTransport();
+    const client = await connectRealClient(transport);
+    const bridge = new WshMcpBridge(client);
+
+    await bridge.discover({ timeout: 2000 });
+    for (let i = 0; i < 10; i++) await bridge.call('read_file', {}, { timeout: 2000 });
+
+    // Nothing the bridge registered may still be attached: install a fresh
+    // probe and confirm it is the only observer an inbound message finds.
+    let observers = 0;
+    const count = () => { observers++; };
+    client.addControlListener(count);
+    transport._emitControl({ type: MSG.MCP_RESULT, result: { success: true, output: 'late' } });
+    client.removeControlListener(count);
+    assert.equal(observers, 1, 'the bridge left listeners registered on the client');
+  });
+
+  it('an untrusted RelayForward is never handed to a control listener', async () => {
+    const transport = new ServerBackedTransport();
+    const client = await connectRealClient(transport);
+
+    const seen = [];
+    client.addControlListener((msg) => seen.push(msg.type));
+
+    // from_fingerprint is not in #acceptedRelayPeers, so the client drops
+    // the envelope. A listener placed before that gate would still see it.
+    transport._emitControl({ type: MSG.RELAY_FORWARD, from_fingerprint: 'not-trusted', inner: new Uint8Array([0xa0]) });
+
+    assert.deepEqual(seen, []);
+  });
+});
+
+describe('control-listener subscription against an onControl-only client', () => {
+  // A bare WshTransport's only hook is the settable `onControl` property.
+  // The inlined registration used to wrap it and never unwrap:
+  //
+  //   const prev = client.onControl;
+  //   client.onControl = (msg) => { prev?.(msg); listener(msg); };
+  //
+  // with a cleanup() that handled only removeControlListener and
+  // _controlListeners. Measured against a real WshTransport, the frames an
+  // inbound message traversed to reach the connection's own handler grew
+  // one per operation: 1, 5, 20, 50 operations gave 5, 9, 24, 54 frames.
+
+  class EchoTransport extends WshTransport {
+    async _doConnect() {}
+    async _doClose() {}
+    async _doSendControl(msg) {
+      if (msg.type === MSG.MCP_CALL) {
+        setTimeout(() => this._emitControl(mcpResult({ result: 'ok' })), 0);
+      }
+    }
+    async _doOpenStream() { throw new Error('not used'); }
+  }
+
+  it('the onControl chain does not grow one wrapper per operation', async () => {
+    const transport = new EchoTransport();
+    await transport.connect('ws://test.invalid');
+
+    let frames = 0;
+    const previousLimit = Error.stackTraceLimit;
+    Error.stackTraceLimit = 500;
+    try {
+      // Stand in for what WshClient.connect() installs.
+      transport.onControl = () => { frames = new Error().stack.split('\n').length; };
+      const bridge = new WshMcpBridge(transport);
+
+      transport._emitControl({ type: MSG.PONG });
+      const baseline = frames;
+
+      for (let i = 0; i < 25; i++) await bridge.call('echo', {}, { timeout: 2000 });
+
+      transport._emitControl({ type: MSG.PONG });
+      assert.equal(
+        frames,
+        baseline,
+        `onControl chain grew from ${baseline} to ${frames} frames over 25 operations`,
+      );
+    } finally {
+      Error.stackTraceLimit = previousLimit;
+    }
+  });
+
+  it('the original onControl handler keeps receiving messages throughout', async () => {
+    const transport = new EchoTransport();
+    await transport.connect('ws://test.invalid');
+
+    const seen = [];
+    transport.onControl = (msg) => seen.push(msg.type);
+    const bridge = new WshMcpBridge(transport);
+
+    await bridge.call('echo', {}, { timeout: 2000 });
+    transport._emitControl({ type: MSG.PONG });
+
+    // Both halves matter. During the call the wrapper is installed, so it
+    // must forward to the handler it displaced; after detach the handler
+    // must be back in place. Dropping either one is silent — the bridge's
+    // own promise resolves regardless.
+    assert.ok(seen.includes(MSG.MCP_RESULT), `handler missed the in-flight reply: ${JSON.stringify(seen)}`);
+    assert.ok(seen.includes(MSG.PONG), `handler stopped receiving after detach: ${JSON.stringify(seen)}`);
+  });
+
+  it('nested subscriptions detach in any order without severing each other', () => {
+    // Wrappers nest, and nothing controls the order they come off in. A
+    // detach that restores `prev` unconditionally looks harmless with one
+    // subscription and silently severs the other here: the inner one puts
+    // the pre-existing handler back and takes the still-live outer wrapper
+    // with it, so the outer subscriber stops receiving anything while its
+    // promise is still pending.
+    const host = { onControl: null };
+    const base = [];
+    host.onControl = (msg) => base.push(`base:${msg.tag}`);
+
+    const outer = [];
+    const inner = [];
+    const detachOuter = attachControlListener(host, (msg) => outer.push(msg.tag));
+    const detachInner = attachControlListener(host, (msg) => inner.push(msg.tag));
+
+    host.onControl({ tag: 'both' });
+    detachOuter();                       // the outer wrapper comes off first,
+    host.onControl({ tag: 'inner-only' }); // while the inner one is still live
+    detachInner();
+    host.onControl({ tag: 'none' });
+
+    assert.deepEqual(inner, ['both', 'inner-only'], 'the inner subscriber was severed by the outer detach');
+    assert.deepEqual(outer, ['both']);
+    assert.deepEqual(base, ['base:both', 'base:inner-only', 'base:none']);
+  });
+});


### PR DESCRIPTION
Three public methods — `WshMcpBridge.discover()`, `WshMcpBridge.call()` and
`WshFileTransfer.list()` — could not be called with the argument their own
JSDoc names. Found by doing the one thing no existing test or example does:
handing them a real `WshClient`.

**Before:** `node --test test/*.test.mjs` → 443 passing.
**After:** 453 passing, zero failures, `npm run examples` clean.

---

## The bug

Both classes are exported from the package root. Both document their
constructor argument as "a WshClient". Both drive the connection through
`sendControl()` plus `addControlListener()`/`removeControlListener()`, and
`list()` additionally needs `openStream()`.

`WshClient` had **none** of those members. Reproduced against a real client
over a real transport, through the real handshake:

```
connected. client shape:
  client.sendControl = undefined
  client.addControlListener = undefined
  client.removeControlListener = undefined
  client._controlListeners = undefined
  client.onControl = undefined
discover(): THREW TypeError: this[#client].sendControl is not a function
MCP_DISCOVER ever reached the transport? false
```

`WshFileTransfer.list()` fails identically. `upload()`/`download()` are fine —
they delegate to `client.upload()`/`client.download()`, which do exist.

This is 0.14.0's `attachSession()`/`resumeSession()` again, and for the same
reason the CHANGELOG gives for that one: every test and both examples build a
stand-in shaped to satisfy the caller (`examples/05` hand-rolls
`{ sendControl, addControlListener, removeControlListener }`;
`test/file-transfer.test.mjs:297` uses
`{ sendControl: async () => {}, openStream: async () => ({}) }`), and a
stand-in written to satisfy the caller cannot disagree with it.

## Second bug, on the same path

For a client whose only hook is a settable `onControl` — which is exactly what
a bare `WshTransport` is — the subscription inlined in both helpers did:

```js
const prev = this.#client.onControl;
this.#client.onControl = (msg) => { prev?.(msg); listener(msg); };
```

and the matching `cleanup()` handled `removeControlListener` and
`_controlListeners` and **nothing at all for this branch**. One permanent
wrapper per operation, never removed. Measured against a real `WshTransport`,
counting the frames an inbound control message traverses to reach the
connection's own handler:

| bridge operations | 0 | 1 | 5 | 20 | 50 |
|---|---|---|---|---|---|
| frames | 4 | 5 | 9 | 24 | 54 |

Linear, no ceiling.

## What changed

- `WshClient` gains `sendControl()`, `openStream()`, `addControlListener()`
  and `removeControlListener()` — thin delegations to the transport it already
  owns and to `#handleControl`, which already sees every inbound control
  message. Listeners are dispatched **after** the RelayForward trust gate, so
  a relayed message from a peer this client has not accepted never reaches
  one, and a trusted RelayForward arrives unwrapped.
- New `src/control-listener.mjs` holds the subscription both helpers used to
  inline. It attaches once, detaches on cleanup, and restores a displaced
  `onControl` **only while its own wrapper is still the installed handler** —
  restoring `prev` unconditionally severs any subscription that nested inside
  it.
- `WshMcpBridge`'s constructor and `WshFileTransfer.list()` now reject a
  client that cannot work, naming the missing member. `WshFileTransfer`'s
  constructor is deliberately unchanged: upload/download need nothing from the
  control channel.
- `src/index.d.ts` declares the four new members.

`WshFileTransfer`'s control-timeout text changed from
`Timeout waiting for response (30000ms)` to
`File transfer response timed out after 30000ms`. Nothing asserts on it.

## Tests

`test/helpers-against-real-client.test.mjs` — ten cases, every one driving a
real `WshClient` over a real `WshTransport` subclass through the real
handshake, asserting on **what reached the wire**, not on what the helper
returned. The server side is in-process, but it sits on the far side of the
client; it never stands in for the client.

## Fault injection

Every test was watched fail before it was kept:

| Injected fault | Red |
|---|---|
| `src/client.mjs` reverted to `main` (the four members gone) | 6 |
| `onControl` detach made a no-op (the original leak) | 1 — *"onControl chain grew from 8 to 33 frames over 25 operations"* |
| `list()`'s precondition guard removed | 1 |
| control listeners dispatched *before* the RelayForward trust gate | 1 |
| wrapper stops forwarding to the handler it displaced | 1 |
| detach restores `prev` unconditionally | 1 — *"the inner subscriber was severed by the outer detach"* |

The last one is worth noting: the first version of that test detached the
subscriptions in the safe order and passed against the broken code. Nesting
only breaks in one direction, and a test that picks the other one proves
nothing.

## What this PR does *not* do

- No real server anywhere in it. The handshake, the messages and the client
  are real; the thing answering is in-process.
- `WshFileTransfer.list()` still shells out to `ls -la` and parses the output.
  That is unchanged here, and it is not a good interface — `fileList()` on the
  client already exists and speaks the file-operation protocol.
- Filed separately rather than fixed here: **#32** (two concurrent
  `callTool()`s return each other's results — `McpCall`/`McpResult` have no
  correlation id, which is a spec + server change) and **#33** (`npm test` on
  `main` is ~95 % reliable; a known 30 s ML-KEM stall intermittently fails an
  unrelated X25519 test).
- `keystore.mjs` (473 lines), `recording.mjs` (402) and `virtual-session.mjs`
  (179) are still imported by no test at all. This PR covers the two modules
  where the missing coverage was hiding a live bug; the rest is still open
  ground.
