### PR TITLE
Check the E2E nonce role tag on receive (#35)

### DIFF
--- a/src/e2e-frame.mjs
+++ b/src/e2e-frame.mjs
@@ -138,12 +138,43 @@ export async function sealFrame(key, sessionId, roleTag, counter, plaintext) {
  * @param {{nonce: Uint8Array, ciphertext: Uint8Array}} frame
  * @returns {Promise<Uint8Array>} plaintext
  */
-export async function openFrame(key, sessionId, expectedCounter, { nonce, ciphertext }) {
+export async function openFrame(key, sessionId, expectedCounter, { nonce, ciphertext, expectedRoleTag }) {
   if (!key || typeof key !== 'object') {
     throw new Error('e2e-frame: openFrame requires a CryptoKey');
   }
   if (!(nonce instanceof Uint8Array) || nonce.length !== NONCE_LENGTH) {
     throw new Error(`e2e-frame: nonce must be a ${NONCE_LENGTH}-byte Uint8Array`);
+  }
+  /*
+   * The role tag is REQUIRED, and a caller that omits it gets an error rather
+   * than a skipped check.
+   *
+   * The tag exists so the two directions of one session are structurally
+   * distinguishable -- it is the reason a colliding nonce is impossible when
+   * both directions share one AES-GCM key. WshSession computed the peer's
+   * expected tag and stored it, and nothing ever read it: `grep -rn
+   * e2eRecvRoleTag` returned the declaration and the assignment and no third
+   * line. So the receiver accepted a frame sealed with its OWN tag, and the
+   * relay this layer exists to distrust could echo a peer's sealed frame
+   * straight back at it. Both counters start at zero, so the first frame of a
+   * session reflects cleanly.
+   *
+   * Optional would have reproduced the defect: a security check nobody is
+   * forced to pass is the same as no check, and this file already had one --
+   * see TimestampProof.verify's ignored verifyFn for the same shape.
+   */
+  if (!(expectedRoleTag instanceof Uint8Array) || expectedRoleTag.length !== ROLE_TAG_LENGTH) {
+    throw new Error(
+      `e2e-frame: openFrame requires expectedRoleTag, a ${ROLE_TAG_LENGTH}-byte Uint8Array`
+    );
+  }
+  const actualRoleTag = nonce.subarray(COUNTER_LENGTH);
+  for (let i = 0; i < ROLE_TAG_LENGTH; i += 1) {
+    if (actualRoleTag[i] !== expectedRoleTag[i]) {
+      throw new Error(
+        'e2e-frame: role tag mismatch -- this frame was sealed by the wrong side of the session'
+      );
+    }
   }
   const actualCounter = Number(new DataView(nonce.buffer, nonce.byteOffset, nonce.byteLength).getBigUint64(0, false));
   if (actualCounter !== expectedCounter) {

--- a/src/session.mjs
+++ b/src/session.mjs
@@ -475,7 +475,7 @@ export class WshSession {
     for (const { nonce, ciphertext } of wireChunks) {
       const counter = this.#e2eRecvCounter++;
       try {
-        const plaintext = await openFrame(this.#e2eKey, this.#sessionId, counter, { nonce, ciphertext });
+        const plaintext = await openFrame(this.#e2eKey, this.#sessionId, counter, { nonce, ciphertext, expectedRoleTag: this.#e2eRecvRoleTag });
         plaintexts.push(plaintext);
       } catch (err) {
         console.error(
@@ -682,7 +682,7 @@ export class WshSession {
         // delivery of *this* frame's plaintext to onData is deferred by
         // one microtask/macrotask relative to synchronous cases.
         const counter = this.#e2eRecvCounter++;
-        openFrame(this.#e2eKey, this.#sessionId, counter, { nonce: msg.nonce, ciphertext: msg.ciphertext })
+        openFrame(this.#e2eKey, this.#sessionId, counter, { nonce: msg.nonce, ciphertext: msg.ciphertext, expectedRoleTag: this.#e2eRecvRoleTag })
           .then((plaintext) => {
             this.#virtualBackend?.pushData(plaintext);
             try {

--- a/test/e2e-frame.test.mjs
+++ b/test/e2e-frame.test.mjs
@@ -17,7 +17,7 @@ describe('e2e-frame', { skip: !hasWebCrypto && 'WebCrypto not available in this 
     const frame = await sealFrame(key, 'session-a', ROLE_TAGS.initiator, 0, plaintext);
     assert.equal(frame.nonce.length, E2E_NONCE_LENGTH);
 
-    const opened = await openFrame(key, 'session-a', 0, frame);
+    const opened = await openFrame(key, 'session-a', 0, { ...frame, expectedRoleTag: ROLE_TAGS.initiator });
     assert.deepEqual([...opened], [...plaintext]);
   });
 
@@ -30,7 +30,7 @@ describe('e2e-frame', { skip: !hasWebCrypto && 'WebCrypto not available in this 
       frames.push(await sealFrame(key, 'session-b', ROLE_TAGS.initiator, i, messages[i]));
     }
     for (let i = 0; i < messages.length; i++) {
-      const opened = await openFrame(key, 'session-b', i, frames[i]);
+      const opened = await openFrame(key, 'session-b', i, { ...frames[i], expectedRoleTag: ROLE_TAGS.initiator });
       assert.deepEqual([...opened], [...messages[i]]);
     }
   });
@@ -43,7 +43,7 @@ describe('e2e-frame', { skip: !hasWebCrypto && 'WebCrypto not available in this 
     const tampered = { nonce: frame.nonce, ciphertext: frame.ciphertext.slice() };
     tampered.ciphertext[0] ^= 0xff;
 
-    await assert.rejects(() => openFrame(key, 'session-c', 0, tampered));
+    await assert.rejects(() => openFrame(key, 'session-c', 0, { ...tampered, expectedRoleTag: ROLE_TAGS.initiator }));
   });
 
   it('tamper detection: a flipped AAD (session_id) fails to open', async () => {
@@ -53,7 +53,7 @@ describe('e2e-frame', { skip: !hasWebCrypto && 'WebCrypto not available in this 
 
     // Attempting to open under a different session_id (simulating a
     // relay splicing ciphertext from one session onto another) must fail.
-    await assert.rejects(() => openFrame(key, 'session-e', 0, frame));
+    await assert.rejects(() => openFrame(key, 'session-e', 0, { ...frame, expectedRoleTag: ROLE_TAGS.initiator }));
   });
 
   it('replay/reorder rejection: an out-of-order or replayed counter is rejected', async () => {
@@ -64,12 +64,12 @@ describe('e2e-frame', { skip: !hasWebCrypto && 'WebCrypto not available in this 
     const frame1 = await sealFrame(key, 'session-f', ROLE_TAGS.initiator, 1, plaintext);
 
     // Replaying frame0 when counter 1 is expected must fail.
-    await assert.rejects(() => openFrame(key, 'session-f', 1, frame0));
+    await assert.rejects(() => openFrame(key, 'session-f', 1, { ...frame0, expectedRoleTag: ROLE_TAGS.initiator }));
     // Skipping ahead (frame1 when 0 is expected) must also fail.
-    await assert.rejects(() => openFrame(key, 'session-f', 0, frame1));
+    await assert.rejects(() => openFrame(key, 'session-f', 0, { ...frame1, expectedRoleTag: ROLE_TAGS.initiator }));
     // The correctly-ordered sequence succeeds.
-    await openFrame(key, 'session-f', 0, frame0);
-    await openFrame(key, 'session-f', 1, frame1);
+    await openFrame(key, 'session-f', 0, { ...frame0, expectedRoleTag: ROLE_TAGS.initiator });
+    await openFrame(key, 'session-f', 1, { ...frame1, expectedRoleTag: ROLE_TAGS.initiator });
   });
 
   it('wrong key fails to open (authentication failure, not silent success)', async () => {
@@ -78,7 +78,7 @@ describe('e2e-frame', { skip: !hasWebCrypto && 'WebCrypto not available in this 
     const plaintext = new TextEncoder().encode('secret');
     const frame = await sealFrame(key, 'session-g', ROLE_TAGS.initiator, 0, plaintext);
 
-    await assert.rejects(() => openFrame(otherKey, 'session-g', 0, frame));
+    await assert.rejects(() => openFrame(otherKey, 'session-g', 0, { ...frame, expectedRoleTag: ROLE_TAGS.initiator }));
   });
 
   it('nonce uniqueness: two consecutive seals from the same sender never produce the same nonce', async () => {
@@ -110,5 +110,54 @@ describe('e2e-frame', { skip: !hasWebCrypto && 'WebCrypto not available in this 
   it('openFrame rejects a malformed nonce length rather than misbehaving', async () => {
     const key = await makeKey();
     await assert.rejects(() => openFrame(key, 'session-i', 0, { nonce: new Uint8Array(4), ciphertext: new Uint8Array(16) }));
+  });
+});
+
+describe('e2e-frame role tag enforcement (#35)', { skip: !hasWebCrypto && 'WebCrypto not available' }, () => {
+  /*
+   * The tag exists so the two directions of one session are structurally
+   * distinguishable, which is what makes a colliding nonce impossible when
+   * both directions share one AES-GCM key. It was computed, stored on the
+   * session, and never read: `grep -rn e2eRecvRoleTag src/` returned the
+   * declaration and the assignment and no third line.
+   *
+   * So a receiver accepted a frame sealed with its OWN tag, and the relay
+   * this layer exists to distrust could echo a peer's sealed frame back at
+   * it. Both counters start at zero, so the first frame of a session
+   * reflects cleanly.
+   *
+   * The old test for this compared ROLE_TAGS.initiator against
+   * ROLE_TAGS.responder -- two frozen constants the test computed itself. It
+   * could only fail if someone edited the constants, and said nothing about
+   * what the receive path does.
+   */
+  it('rejects a frame sealed by the wrong side of the session', async () => {
+    const key = await makeKey();
+    const plaintext = new TextEncoder().encode('reflected back at the sender');
+
+    // The initiator seals. A relay echoes it straight back, so the initiator
+    // sees a frame carrying its own tag where the responder's belongs.
+    const reflected = await sealFrame(key, 'session-reflect', ROLE_TAGS.initiator, 0, plaintext);
+
+    await assert.rejects(
+      () => openFrame(key, 'session-reflect', 0, { ...reflected, expectedRoleTag: ROLE_TAGS.responder }),
+      /role tag mismatch/,
+    );
+
+    // The genuine direction still opens, so the check is not simply refusing.
+    const genuine = await sealFrame(key, 'session-reflect', ROLE_TAGS.responder, 0, plaintext);
+    const opened = await openFrame(key, 'session-reflect', 0, { ...genuine, expectedRoleTag: ROLE_TAGS.responder });
+    assert.deepEqual([...opened], [...plaintext]);
+  });
+
+  it('refuses to open a frame at all when no tag is supplied', async () => {
+    // An optional check is the same as no check -- which is how this got
+    // shipped. A caller that forgets gets an error, not a silent skip.
+    const key = await makeKey();
+    const frame = await sealFrame(key, 'session-nofail', ROLE_TAGS.initiator, 0, new Uint8Array([1]));
+    await assert.rejects(
+      () => openFrame(key, 'session-nofail', 0, frame),
+      /requires expectedRoleTag/,
+    );
   });
 });

--- a/test/stream-frame.test.mjs
+++ b/test/stream-frame.test.mjs
@@ -28,7 +28,7 @@ describe('stream-frame: ChunkAccumulator + encodeChunk', { skip: !hasWebCrypto &
     const chunks = acc.feed(wire);
     assert.equal(chunks.length, 1);
 
-    const opened = await openFrame(key, 'sess-1', 0, chunks[0]);
+    const opened = await openFrame(key, 'sess-1', 0, { ...chunks[0], expectedRoleTag: ROLE_TAGS.initiator });
     assert.deepEqual([...opened], [...plaintext]);
     assert.doesNotThrow(() => acc.finish());
   });
@@ -46,7 +46,7 @@ describe('stream-frame: ChunkAccumulator + encodeChunk', { skip: !hasWebCrypto &
     const [chunk] = acc.feed(tampered);
     assert.ok(chunk);
 
-    await assert.rejects(() => openFrame(key, 'sess-2', 0, chunk));
+    await assert.rejects(() => openFrame(key, 'sess-2', 0, { ...chunk, expectedRoleTag: ROLE_TAGS.initiator }));
   });
 
   it('finish() throws StreamTornChunkError for a torn chunk left at EOF', () => {
@@ -79,7 +79,7 @@ describe('stream-frame: ChunkAccumulator + encodeChunk', { skip: !hasWebCrypto &
     const chunks = acc.feed(combined);
     assert.equal(chunks.length, 3);
 
-    const opened = await Promise.all(chunks.map((chunk, i) => openFrame(key, 'sess-3', i, chunk)));
+    const opened = await Promise.all(chunks.map((chunk, i) => openFrame(key, 'sess-3', i, { ...chunk, expectedRoleTag: ROLE_TAGS.initiator })));
     assert.equal(new TextDecoder().decode(opened[0]), 'first chunk');
     assert.equal(new TextDecoder().decode(opened[1]), 'second chunk');
     assert.equal(new TextDecoder().decode(opened[2]), 'third chunk');
@@ -101,7 +101,7 @@ describe('stream-frame: ChunkAccumulator + encodeChunk', { skip: !hasWebCrypto &
     const chunksAfterSecond = acc.feed(second);
     assert.equal(chunksAfterSecond.length, 1);
 
-    const opened = await openFrame(key, 'sess-4', 0, chunksAfterSecond[0]);
+    const opened = await openFrame(key, 'sess-4', 0, { ...chunksAfterSecond[0], expectedRoleTag: ROLE_TAGS.initiator });
     assert.deepEqual([...opened], [...plaintext]);
     assert.doesNotThrow(() => acc.finish());
   });
@@ -119,7 +119,7 @@ describe('stream-frame: ChunkAccumulator + encodeChunk', { skip: !hasWebCrypto &
     const chunks = acc.feed(second);
     assert.equal(chunks.length, 1);
 
-    const opened = await openFrame(key, 'sess-5', 0, chunks[0]);
+    const opened = await openFrame(key, 'sess-5', 0, { ...chunks[0], expectedRoleTag: ROLE_TAGS.initiator });
     assert.deepEqual([...opened], [...plaintext]);
   });
 
@@ -133,7 +133,7 @@ describe('stream-frame: ChunkAccumulator + encodeChunk', { skip: !hasWebCrypto &
       chunks = chunks.concat(acc.feed(Uint8Array.of(byte)));
     }
     assert.equal(chunks.length, 1);
-    const opened = await openFrame(key, 'sess-6', 0, chunks[0]);
+    const opened = await openFrame(key, 'sess-6', 0, { ...chunks[0], expectedRoleTag: ROLE_TAGS.initiator });
     assert.deepEqual([...opened], [...plaintext]);
   });
 });


### PR DESCRIPTION
Closes #35.

`WshSession` computed the peer's expected role tag and stored it. **Nothing read it** — `grep -arn e2eRecvRoleTag src/` returned the declaration and the assignment and no third line — and `openFrame` took no tag to check.

Both directions of a session share one AES-GCM key, and the role tag is the only thing distinguishing them. With it ignored, **a receiver accepted a frame sealed with its own tag**: the relay this layer exists to distrust could echo a peer's sealed frame back and have it decrypt as inbound peer data. The counter check is a partial mitigation, not a defence — both counters start at 0, so the first frame reflects cleanly.

### Required, not optional

`openFrame` now **requires** `expectedRoleTag`. A security check nobody is forced to pass is the same as no check — which is exactly how this shipped. A caller that omits it gets an error, not a silent skip.

### The old test could not have caught it

```js
const initiatorNonce = buildNonce(0, ROLE_TAGS.initiator);
const responderNonce = buildNonce(0, ROLE_TAGS.responder);
assert.notDeepEqual([...initiatorNonce], [...responderNonce]);
```

Two frozen constants the test computed itself. It can only fail if someone edits the constants, and says nothing about the receive path.

The new one seals as initiator, opens as responder, expects refusal — and a second pins the missing-tag error so the parameter cannot quietly become optional again. Both fail with the comparison removed.

**445 pass, 0 fail.**