### PR TITLE
The keepalive recorded the pong and never acted on it (#38)

### DIFF
--- a/src/client.mjs
+++ b/src/client.mjs
@@ -81,6 +81,12 @@ function requireArgs(method, args) {
   }
 }
 const DEFAULT_PING_INTERVAL  = 30_000;  // ms
+/*
+ * How long a peer may go without answering a ping before it is treated as
+ * gone. A multiple of the interval, so an ordinary missed pong is tolerated
+ * and a peer that has genuinely stopped answering is not.
+ */
+const DEFAULT_PONG_TIMEOUT   = 90_000;  // ms
 const DEFAULT_EXEC_TIMEOUT   = 60_000;  // ms
 const FILE_CHUNK_SIZE        = 65_536;
 
@@ -236,12 +242,21 @@ export class WshClient {
 
   /** @type {number|null} Timestamp of last pong received. */
   #lastPong = null;
+  #pingIntervalMs = DEFAULT_PING_INTERVAL;
+  #pongTimeoutMs = DEFAULT_PONG_TIMEOUT;
 
-  constructor({ transportFactories } = {}) {
+  constructor({ transportFactories, pingIntervalMs, pongTimeoutMs } = {}) {
     this.#transportFactories = transportFactories || {
       wt: () => new WebTransportTransport(),
       ws: () => new WebSocketTransport(),
     };
+    /*
+     * Overridable so the keepalive is testable at all. Left as constants,
+     * the only way to observe a 90s timeout is to wait 90s or fake the
+     * clock -- which is why nothing observed it before.
+     */
+    this.#pingIntervalMs = pingIntervalMs ?? DEFAULT_PING_INTERVAL;
+    this.#pongTimeoutMs = pongTimeoutMs ?? DEFAULT_PONG_TIMEOUT;
   }
 
   // ── Callbacks ───────────────────────────────────────────────────────
@@ -2282,12 +2297,37 @@ export class WshClient {
         return;
       }
 
+      /*
+       * Act on the pong, rather than merely recording it.
+       *
+       * `#lastPong` was written on every PONG and read nowhere -- `grep -arn
+       * lastPong src/` returned the declaration and two assignments and no
+       * third line. So the keepalive proved the connection was alive when it
+       * was, and said nothing when it stopped being: pings went out forever
+       * at every peer, dead or not, and a caller waiting for data waited
+       * without a reason.
+       *
+       * Compared against a deadline rather than armed as a timer, which
+       * matters: a timer re-armed on each tick is cleared before it can fire
+       * whenever the interval is shorter than the timeout, and is then
+       * incapable of firing at all. (browsermesh#32 shipped exactly that.) A
+       * timestamp comparison has no such failure mode.
+       */
+      if (this.#lastPong !== null && Date.now() - this.#lastPong > this.#pongTimeoutMs) {
+        const silentFor = Date.now() - this.#lastPong;
+        this.#stopPing();
+        this.#emitError(
+          new Error(`wsh: peer stopped answering keepalive pings ${silentFor}ms ago`)
+        );
+        return;
+      }
+
       this.#transport?.sendControl(
         pingMsg({ id: ++this.#pingId })
       ).catch((err) => {
         console.warn('[wsh:client] Failed to send ping:', err.message);
       });
-    }, DEFAULT_PING_INTERVAL);
+    }, this.#pingIntervalMs);
 
     // Don't let the ping timer prevent Node.js/Deno from exiting.
     if (typeof this.#pingTimer === 'object' && this.#pingTimer.unref) {

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -1203,3 +1203,50 @@ describe('WshSession E2E guards, at the level that chooses the arguments', () =>
     assert.deepEqual(delivered, ['deliver me exactly once'], 'the replay is refused');
   });
 });
+
+// ---------------------------------------------------------------------------
+// The keepalive acts on the pong it records (#38)
+// ---------------------------------------------------------------------------
+
+describe('keepalive detects a peer that stops answering', () => {
+  /*
+   * `#lastPong` was written on every PONG and read nowhere -- `grep -arn
+   * lastPong src/` returned the declaration and two assignments and no third
+   * line. The keepalive proved the connection alive when it was and said
+   * nothing when it stopped being: pings went out forever at a dead peer.
+   *
+   * The timings are injectable now because at the shipped 30s/90s they are
+   * unobservable without faking the clock, which is the reason nothing
+   * observed them.
+   */
+  it('reports an error once the peer has been silent past the timeout', async () => {
+    const keyPair = await auth.generateKeyPair(true);
+    const transport = new StandardHandshakeMockTransport('sess-keepalive');
+    const originalSend = transport._doSendControl.bind(transport);
+    let pings = 0;
+    transport._doSendControl = async (msg) => {
+      await originalSend(msg);
+      if (msg.type === MSG.HELLO) setTimeout(() => transport.emitChallenge(), 1);
+      // A peer that is gone: it accepts the ping and never pongs.
+      if (msg.type === MSG.PING) pings += 1;
+    };
+
+    const client = new clientMod.WshClient({
+      transportFactories: { ws: () => transport },
+      pingIntervalMs: 10,
+      pongTimeoutMs: 40,
+    });
+
+    const errors = [];
+    client.onError = (err) => errors.push(err.message);
+
+    await client.connect('ws://test.invalid', { username: 'carol', keyPair, transport: 'ws' });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    assert.ok(pings > 0, 'the keepalive was actually running');
+    assert.ok(
+      errors.some((m) => /stopped answering keepalive/.test(m)),
+      `a silent peer is reported; saw ${JSON.stringify(errors)} after ${pings} pings`,
+    );
+  });
+});


### PR DESCRIPTION
Closes #38.

`#lastPong` was written on every PONG and **read nowhere** — `grep -arn lastPong src/` returns the declaration and two assignments and no third line.

So the keepalive proved the connection alive while it was, and said nothing when it stopped being. Pings went out on the interval forever, at a live peer and a dead one alike, and a caller waiting for data waited without being told why.

### Compared, not armed

The tick now compares `Date.now() - #lastPong` against `pongTimeoutMs` and raises the connection error the client already has a channel for.

**A timestamp comparison, deliberately — not a timer.** A timeout re-armed on every tick is cleared before it can fire whenever the interval is shorter than the timeout, which makes it *incapable* of firing. browsermesh#32 shipped exactly that shape: 15 s pings clearing a 60 s timeout, 21 unanswered pings and still `active`. This form has no such failure mode.

### Testability was the reason it went unnoticed

`pingIntervalMs` and `pongTimeoutMs` are constructor options now, defaulting to the previous constants. At the shipped 30 s / 90 s the behaviour cannot be observed without faking the clock — which is why nothing observed it. The test drives 10 ms / 40 ms against a transport that accepts pings and never pongs.

With the comparison stubbed out — the behaviour as shipped — that test fails and nothing else does.

**540 pass, 0 fail.**