### PR TITLE
The two ways a session closes did not agree (#36, #37)

### DIFF
--- a/src/session.mjs
+++ b/src/session.mjs
@@ -153,6 +153,8 @@ export class WshSession {
    * @type {ReturnType<typeof setTimeout>|null}
    */
   #closeGraceTimer = null;
+  /** Why the session closed, when it closed for a reason worth naming. */
+  #closeReason = null;
 
   // ── Callbacks ───────────────────────────────────────────────────────
 
@@ -724,14 +726,7 @@ export class WshSession {
         // any pending data-EOF grace timer, regardless of which arrived
         // first.
         this.#clearCloseGraceTimer();
-        if (this.#state !== STATE_CLOSED) {
-          this.#state = STATE_CLOSED;
-          this.#abort.abort();
-          this.#virtualBackend?.close();
-          this.#releaseStreams();
-          this.#resolvePendingFileChunk(null);
-          this.#emitClose();
-        }
+        this.#closeNow();
         break;
       }
 
@@ -874,11 +869,32 @@ export class WshSession {
           if (this.#e2eKey !== null && this.#streamAccumulator) {
             const deliverable = await this.#openStreamChunks(value);
             if (deliverable === null) {
-              // Authentication failure (or corrupt framing) -- matches
-              // the strict "no skip-and-continue" philosophy of
-              // virtual-mode's counter check: tear the session down
-              // rather than deliver anything from this point on.
-              break;
+              /*
+               * Authentication failure (or corrupt framing) -- the strict
+               * "no skip-and-continue" philosophy of virtual-mode's counter
+               * check: tear the session down rather than deliver anything
+               * from this point on.
+               *
+               * `break` alone did not tear anything down. It left the loop,
+               * and control fell through to the data-EOF grace timer, so the
+               * session stayed `active` and writable for the full 300ms and
+               * then closed as an ordinary EOF: onClose with no error,
+               * onExit never fired, exitCode still null. An application could
+               * not tell "the peer forged data at me" from "the process
+               * exited and the server forgot to send CLOSE" -- the two were
+               * byte-identical to observe.
+               *
+               * Closed immediately, and the reason recorded so the two are
+               * distinguishable. `StreamAuthenticationError` was already
+               * built here and handed only to console.error; it is now the
+               * close reason as well.
+               */
+              this.#closeReason = new StreamAuthenticationError(
+                'wsh: stream authentication failed -- session torn down'
+              );
+              this.#clearCloseGraceTimer();
+              this.#closeNow();
+              return;
             }
             for (const plaintext of deliverable) {
               try {
@@ -918,11 +934,7 @@ export class WshSession {
     if (this.#state !== STATE_CLOSED && this.#closeGraceTimer === null) {
       this.#closeGraceTimer = setTimeout(() => {
         this.#closeGraceTimer = null;
-        if (this.#state !== STATE_CLOSED) {
-          this.#state = STATE_CLOSED;
-          this.#releaseStreams();
-          this.#emitClose();
-        }
+        this.#closeNow();
       }, DATA_EOF_CLOSE_GRACE_MS);
       this.#closeGraceTimer?.unref?.();
     }
@@ -935,6 +947,36 @@ export class WshSession {
    * whether or not a timer is currently scheduled.
    * @private
    */
+  /**
+   * Close the session once, releasing everything a close has to release.
+   *
+   * There were two ways a stream-mode session reached `closed` and they did
+   * not agree. The CLOSE control handler aborted, closed the virtual backend,
+   * released the streams AND settled any parked file chunk. The data-EOF
+   * grace fallback -- the path taken when a server ends the data stream
+   * without sending CLOSE, which the comment above it says is real -- only
+   * released the streams and fired onClose.
+   *
+   * So `download()`, parked on `_readFileChunk()`, was never settled on that
+   * path. It documents returning `null` for a truncated transfer and
+   * `download()` turns that into a thrown error; via the fallback it returned
+   * nothing at all and the download hung forever, while `onClose` had already
+   * fired and the session read `closed`.
+   *
+   * One method rather than two call sites kept in step by hand: the drift is
+   * the bug, and the next field added to a close would have drifted the same
+   * way.
+   */
+  #closeNow() {
+    if (this.#state === STATE_CLOSED) return;
+    this.#state = STATE_CLOSED;
+    this.#abort.abort();
+    this.#virtualBackend?.close();
+    this.#releaseStreams();
+    this.#resolvePendingFileChunk(null);
+    this.#emitClose();
+  }
+
   #clearCloseGraceTimer() {
     if (this.#closeGraceTimer !== null) {
       clearTimeout(this.#closeGraceTimer);
@@ -961,9 +1003,19 @@ export class WshSession {
    * Emit the onClose callback exactly once.
    * @private
    */
+  /**
+   * Why the session closed, or null for an ordinary close.
+   *
+   * A torn-down session and a clean exit used to be indistinguishable from
+   * the outside; this is what tells them apart.
+   */
+  get closeReason() {
+    return this.#closeReason;
+  }
+
   #emitClose() {
     try {
-      this.onClose?.();
+      this.onClose?.(this.#closeReason);
     } catch (err) {
       console.error('[wsh:session] onClose handler error:', err);
     }

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -987,11 +987,31 @@ describe('Stream-mode EncryptedFrame chunk framing end-to-end integration', { sk
       delivered = true;
     };
 
+    let closedWith = 'not-closed';
+    sessionB.onClose = (reason) => { closedWith = reason; };
+
     await sessionA.write('will be tampered with on the raw stream');
     // Give the async openFrame()/pump loop a turn to run.
     await new Promise((resolve) => setTimeout(resolve, 20));
 
     assert.equal(delivered, false);
+
+    /*
+     * `delivered === false` on its own proved nothing about the teardown:
+     * #openStreamChunks returns null before onData is ever reached, so it
+     * held whether the session tore down or not. Replacing the `break` with
+     * `continue` -- removing the teardown entirely -- left this test green.
+     *
+     * And 20ms sits inside the 300ms data-EOF grace window, so an immediate
+     * teardown and no teardown at all looked identical at the moment of
+     * assertion. What follows is what actually distinguishes them.
+     */
+    assert.equal(sessionB.state, 'closed', 'a forged frame tears the session down at once');
+    assert.ok(
+      closedWith instanceof Error,
+      `onClose carries the reason; got ${JSON.stringify(closedWith)}`,
+    );
+    assert.match(String(closedWith.message), /authentication failed/);
   });
 });
 
@@ -1279,5 +1299,54 @@ describe('keepalive detects a peer that stops answering', () => {
       errors.some((m) => /stopped answering keepalive/.test(m)),
       `a silent peer is reported; saw ${JSON.stringify(errors)} after ${pings} pings`,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Both ways a session closes must settle a parked file chunk (#36)
+// ---------------------------------------------------------------------------
+
+describe('a stream-mode session that EOFs without CLOSE', () => {
+  /*
+   * There were two routes to `closed` and they disagreed. The CLOSE control
+   * handler settled a parked `_readFileChunk()` with null; the data-EOF grace
+   * fallback -- taken when a server ends the data stream without sending
+   * CLOSE, which the comment beside it says is real -- did not.
+   *
+   * `download()` parks on `_readFileChunk()` and turns a null into a thrown
+   * "truncated" error. Via the fallback it got nothing at all: the promise
+   * never settled, so the download hung forever while `onClose` had already
+   * fired and the session read `closed`.
+   *
+   * No test could see it: the file-transfer mock forces virtual mode on every
+   * channel and its `_doOpenStream` is a tripwire, so nothing in the suite
+   * ever ran a stream-mode file session or armed that timer.
+   */
+  it('settles a parked file chunk instead of hanging the caller', async () => {
+    const sessionModule = await import('../src/session.mjs');
+    const { WshSession } = sessionModule;
+
+    const dummyTransport = { sendControl: async () => {} };
+    const session = new WshSession(dummyTransport, 7, {}, 'file', {
+      dataMode: 'stream',
+      sessionId: 'sess-eof-file',
+    });
+
+    // A data stream that ends immediately and no CLOSE ever arrives.
+    const empty = new ReadableStream({ start(controller) { controller.close(); } });
+    session._bind(empty, new WritableStream());
+
+    // What download() does: park on the next chunk.
+    const parked = session._readFileChunk();
+
+    // Past the 300ms data-EOF grace, the fallback closes the session.
+    const settled = await Promise.race([
+      parked.then((v) => ({ settled: true, value: v })),
+      new Promise((resolve) => setTimeout(() => resolve({ settled: false }), 1500)),
+    ]);
+
+    assert.equal(settled.settled, true, 'the parked read settles rather than hanging forever');
+    assert.equal(settled.value, null, 'and reports the truncation download() turns into an error');
+    assert.equal(session.state, 'closed');
   });
 });


### PR DESCRIPTION
Closes #36. Closes #37. Both are real production defects, not test gaps.

### #36 — a parked file read was never settled on one of the two close paths

The CLOSE control handler aborted, closed the virtual backend, released the streams **and settled any parked file chunk**. The data-EOF grace fallback — taken when a server ends the data stream without sending CLOSE, which the comment beside it says is real — only released the streams and fired `onClose`.

`download()` parks on `_readFileChunk()` and turns a `null` into a thrown *"truncated"* error. Via the fallback it got **nothing**: the promise never settled, so the download hung forever while `onClose` had already fired and the session read `closed`.

Both routes now call one `#closeNow()`. Two call sites kept in step by hand *was* the bug — the next field added to a close would have drifted the same way.

### #37 — an authentication failure tore nothing down

`deliverable === null` means AES-GCM authentication failed: an active tamperer, or a forged/spliced ciphertext. The comment said *"tear the session down"*; the code said `break`, which only leaves the loop. Nothing aborted, nothing closed, no error surfaced — control fell through to the same EOF grace timer, so the session stayed **active and writable for 300 ms** then closed as an ordinary EOF. `onClose` with no error, `onExit` never fired, `exitCode` null.

An application could not tell *"the peer forged data at me"* from *"the process exited and the server forgot to send CLOSE"*.

It now closes at once and records why, exposed as `session.closeReason` and passed to `onClose`.

### The tests

The tampered-chunk test observed `delivered === false` **and nothing else** — which held whether the session tore down or not (`#openStreamChunks` returns null before `onData` is reached), and 20 ms sits inside the 300 ms grace, so immediate teardown and none looked identical. It now asserts state and reason, and fails under the issue's own mutation.

#36 needed a new test: the file-transfer mock forces virtual mode on every channel and its `_doOpenStream` is a tripwire, so nothing ever ran a stream-mode file session or armed that timer.

**Removing `#resolvePendingFileChunk(null)` doesn't merely fail that test — the suite stops terminating at all**, which is the hang the issue describes, observed directly.

**542 pass, 0 fail.**

Note for publishing: `onClose` now receives a reason argument and `closeReason` is a new getter — additive, but `onClose` handlers that were declared with no parameters are unaffected while ones using `arguments` may see a change.