### PR TITLE
The noble ML-KEM backend had never executed (#42)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      # The package has no runtime dependencies, so this was omitted -- but
+      # @noble/post-quantum is an OPTIONAL one, and it is the only ML-KEM
+      # backend a browser can use. Without an install step the noble path
+      # cannot run here, which is why it had never been executed in CI. See
+      # #42.
+      - run: npm install --no-save --include=optional
       - run: npm test
       - name: Examples smoke test
         run: npm run examples

--- a/src/mlkem.mjs
+++ b/src/mlkem.mjs
@@ -66,7 +66,34 @@ function bytesEqual(a, b) {
   return diff === 0;
 }
 
+/**
+ * Which implementation serves ML-KEM-768, with an override for testing.
+ *
+ * The noble branch is the ONLY path a browser can take -- no browser
+ * implements the experimental WebCrypto ML-KEM draft -- and until this
+ * override existed no test had ever executed a line of it. `getBackend()`
+ * memoised a probe that always succeeds on the repo's target runtime, so
+ * every assertion ran against native, and every noble call
+ * (`ml_kem768.keygen`, `.encapsulate`, `.decapsulate`) was untouched. A
+ * change in noble's argument order or seed semantics -- it is pinned only to
+ * `^0.7.0` and called through three positional APIs -- would break hybrid PQ
+ * key exchange for every browser consumer while this repo stayed green.
+ *
+ * `WSH_MLKEM_BACKEND=noble` forces it. Read defensively: this module runs in
+ * browsers, where `process` does not exist.
+ */
+function backendOverride() {
+  try {
+    const value = globalThis.process?.env?.WSH_MLKEM_BACKEND;
+    return value === 'noble' || value === 'native' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 async function getBackend() {
+  const forced = backendOverride();
+  if (forced) return forced;
   if (!backendPromise) {
     backendPromise = probeNativeSupport().then((supported) => (supported ? 'native' : 'noble'));
   }

--- a/test/mlkem.test.mjs
+++ b/test/mlkem.test.mjs
@@ -82,3 +82,68 @@ describe('mlkem', { skip: !mlkem && 'ML-KEM-768 module failed to import' }, () =
     await assert.rejects(() => mlkem.mlKemDecapsulate(secretKeySeed, new Uint8Array(10)));
   });
 });
+
+// ---------------------------------------------------------------------------
+// The noble path, which is the only one a browser can take (#42)
+// ---------------------------------------------------------------------------
+//
+// `getBackend()` memoised a probe that always succeeds on this repo's target
+// runtime, so every assertion above ran against native and not one line of
+// the noble branch had ever executed -- `ml_kem768.keygen`, `.encapsulate`
+// and `.decapsulate` included. No browser implements the experimental
+// WebCrypto ML-KEM draft, so noble is what every browser consumer of
+// `initiateE2E(..., 'X25519+ML-KEM-768')` actually runs.
+//
+// The file's own header claimed it exercised "whichever backend this runtime
+// actually selects", and its skip guard claimed to catch a missing noble --
+// unreachable, since the import is lazy and there is no top-level probe.
+//
+// WSH_MLKEM_BACKEND forces the choice. The env var is read per call, not
+// memoised, which is what lets one process play both peers.
+
+const nobleAvailable = await import('@noble/post-quantum/ml-kem.js').then(() => true, () => false);
+
+describe('ML-KEM-768 noble backend', { skip: !nobleAvailable && '@noble/post-quantum is not installed' }, () => {
+  const withBackend = async (name, fn) => {
+    const previous = process.env.WSH_MLKEM_BACKEND;
+    process.env.WSH_MLKEM_BACKEND = name;
+    try { return await fn(); } finally {
+      if (previous === undefined) delete process.env.WSH_MLKEM_BACKEND;
+      else process.env.WSH_MLKEM_BACKEND = previous;
+    }
+  };
+
+  it('round-trips entirely on noble', async () => {
+    await withBackend('noble', async () => {
+      const kp = await mlkem.generateMlKemKeyPair();
+      assert.equal(kp.publicKey.length, mlkem.MLKEM768_PUBLIC_KEY_LENGTH);
+      const enc = await mlkem.mlKemEncapsulate(kp.publicKey);
+      assert.equal(enc.ciphertext.length, mlkem.MLKEM768_CIPHERTEXT_LENGTH);
+      const shared = await mlkem.mlKemDecapsulate(kp.secretKeySeed, enc.ciphertext);
+      assert.deepEqual([...shared], [...enc.sharedSecret]);
+    });
+  });
+
+  it('a browser peer and a Node peer derive the SAME secret', async () => {
+    /*
+     * The failure this guards against is not a crash. If noble's argument
+     * order or seed semantics drift from the native draft -- it is pinned
+     * only to ^0.7.0 and called through three positional APIs -- the two
+     * sides still complete, and derive DIFFERENT secrets. Every frame
+     * afterwards fails to open, far from the cause.
+     *
+     * Both directions, because either peer may be the browser.
+     */
+    const nativeKeys = await withBackend('native', () => mlkem.generateMlKemKeyPair());
+    const fromNoble = await withBackend('noble', () => mlkem.mlKemEncapsulate(nativeKeys.publicKey));
+    const atNative = await withBackend('native', () =>
+      mlkem.mlKemDecapsulate(nativeKeys.secretKeySeed, fromNoble.ciphertext));
+    assert.deepEqual([...atNative], [...fromNoble.sharedSecret], 'noble -> native');
+
+    const nobleKeys = await withBackend('noble', () => mlkem.generateMlKemKeyPair());
+    const fromNative = await withBackend('native', () => mlkem.mlKemEncapsulate(nobleKeys.publicKey));
+    const atNoble = await withBackend('noble', () =>
+      mlkem.mlKemDecapsulate(nobleKeys.secretKeySeed, fromNative.ciphertext));
+    assert.deepEqual([...atNoble], [...fromNative.sharedSecret], 'native -> noble');
+  });
+});


### PR DESCRIPTION
Closes #42.

No browser implements the experimental WebCrypto ML-KEM-768 draft, so **the noble branch is the only path a browser consumer can take** — and not one line of it had ever run here.

`getBackend()` memoised a probe that always succeeds on this repo's target runtime, so every assertion ran against native. `ml_kem768.keygen`, `.encapsulate`, `.decapsulate`: untouched. The file's header claimed it exercised *"whichever backend this runtime actually selects"*, and its skip guard claimed to catch a missing noble — unreachable, since the import is lazy and there is no top-level probe.

**CI could not have run it either**: the workflow has no install step at all. The package has zero runtime dependencies so none was needed — but noble is an *optional* one, and without it the branch is simply absent.

### What changed

- `WSH_MLKEM_BACKEND` forces the backend, read **per call** rather than memoised — which is what lets one process play both peers. Read through `globalThis.process?.env`, since this module runs in browsers.
- CI gains `npm install --no-save --include=optional`.
- Two tests: a full noble round trip, and **a native peer and a noble peer deriving the same shared secret, both directions**.

### The second test is the one that matters

It guards a failure that is *not a crash*. If noble's argument order or seed semantics drift — pinned only to `^0.7.0`, called through three positional APIs — both sides still complete and derive **different** secrets, and every frame afterwards fails to open, far from the cause.

Swapping `ml_kem768.decapsulate`'s arguments fails both new tests. Before them it was invisible.

**Worth stating what does *not* catch it:** dropping the `randomness` argument from `encapsulate` leaves the suite green, because random and supplied randomness both yield a valid pair. Not every drift is detectable this way.

### Deliberately not done

No lockfile is committed — the repo has never had one, and with zero runtime dependencies that's a reasonable choice, so I haven't introduced one. The `^0.7.0` pin is unchanged (my install bumped it to `^0.7.1`; I reverted that).

**545 pass, 0 fail**, with both backends exercised for the first time.