### PR TITLE
Correlate MCP calls with a call_id (#32)

### DIFF
--- a/spec/codegen.mjs
+++ b/spec/codegen.mjs
@@ -287,8 +287,10 @@ function emitJS(schema) {
 
     // ── Special case: McpCall (arguments is a reserved word) ─────────
     if (msg.name === 'McpCall') {
-      out.push('export function mcpCall({ tool, arguments: args } = {}) {');
-      out.push('  return { type: MSG.MCP_CALL, tool, arguments: args };');
+      out.push('export function mcpCall({ tool, arguments: args, callId } = {}) {');
+      out.push('  const m = { type: MSG.MCP_CALL, tool, arguments: args };');
+      out.push('  if (callId !== undefined) m.call_id = callId;');
+      out.push('  return m;');
       out.push('}');
       out.push('');
       continue;

--- a/spec/wsh-v1.md
+++ b/spec/wsh-v1.md
@@ -567,6 +567,7 @@ Category: **mcp**
 |-------|------|----------|---------|
 | `tool` | `string` | yes | — |
 | `arguments` | `json` | yes | — |
+| `call_id` | `string` | no | — |
 
 ### McpResult (`0x43`)
 
@@ -577,6 +578,7 @@ Category: **mcp**
 | Field | Type | Required | Default |
 |-------|------|----------|---------|
 | `result` | `json` | yes | — |
+| `call_id` | `string` | no | — |
 
 ### ReverseRegister (`0x50`)
 

--- a/spec/wsh-v1.yaml
+++ b/spec/wsh-v1.yaml
@@ -613,7 +613,7 @@ messages:
       code: 0x42
       description: >
         Invoke an MCP tool by name with JSON arguments.
-        The server replies with McpResult.
+        The server replies with McpResult carrying the same call_id.
       fields:
         tool:
           type: string
@@ -621,6 +621,15 @@ messages:
         arguments:
           type: json
           required: true
+        call_id:
+          type: string
+          required: false
+          description: >
+            Correlates this call with its McpResult.  Optional for
+            backward compatibility with peers predating it: when absent,
+            a client with more than one call in flight cannot tell the
+            replies apart and may return one call's result to another.
+            Senders SHOULD always set it.
 
     McpResult:
       code: 0x43
@@ -631,6 +640,13 @@ messages:
         result:
           type: json
           required: true
+        call_id:
+          type: string
+          required: false
+          description: >
+            Echoed verbatim from the McpCall this answers.  Responders
+            MUST echo it when the call carried one; omitting it forces
+            the caller back on type-only matching.
 
   reverse:
     ReverseRegister:

--- a/src/client.mjs
+++ b/src/client.mjs
@@ -54,6 +54,15 @@ const DEFAULT_AUTH_TIMEOUT   = 10_000;  // ms
 const DEFAULT_OPEN_TIMEOUT   = 10_000;  // ms
 
 /**
+ * ServerHello feature advertising that McpResult echoes McpCall's call_id.
+ *
+ * Negotiated rather than assumed: McpCallPayload is `deny_unknown_fields` on
+ * the Rust side, so sending call_id to a server predating it does not
+ * degrade -- it makes the server reject the call.
+ */
+export const MCP_CALL_ID_FEATURE = 'mcp-call-id';
+
+/**
  * Reject a missing argument that maps to a `required: true` wire field.
  *
  * JavaScript will happily let an omitted argument through, and
@@ -224,6 +233,17 @@ export class WshClient {
 
   /** @type {number} Monotonically increasing channel ID counter. */
   #channelCounter = 0;
+
+  /** @type {number} Monotonically increasing MCP call counter for call_id. */
+  #mcpCallCounter = 0;
+
+  /**
+   * Tail of the serialised MCP call chain, used only against servers that do
+   * not advertise `mcp-call-id`. Never rejects: each link swallows so one
+   * failed call does not poison the queue.
+   * @type {Promise<void>}
+   */
+  #mcpQueue = Promise.resolve();
 
   /**
    * Pending message waiters: Map<messageType, Array<{resolve, reject, timer}>>
@@ -1259,6 +1279,12 @@ export class WshClient {
   /**
    * Call an MCP tool on the remote server.
    *
+   * Safe to call concurrently. Against a server advertising the
+   * `mcp-call-id` feature each call carries a correlation id and takes only
+   * its own reply. Against an older server there is no id on the wire and
+   * replies are indistinguishable, so calls are queued one at a time on this
+   * connection -- slower, but never the wrong tool's result.
+   *
    * @param {string} name - Tool name
    * @param {object} [args={}] - Tool arguments. Defaults to `{}` rather
    *   than being omitted: `McpCall.arguments` is a required wire field,
@@ -1270,14 +1296,43 @@ export class WshClient {
     this.#assertAuthenticated('callTool');
     requireArgs('callTool', { name });
 
+    if (this.hasFeature(MCP_CALL_ID_FEATURE)) {
+      return this.#callToolCorrelated(name, args, timeout);
+    }
+    // No correlation available: serialise so a concurrent caller cannot be
+    // handed someone else's result.
+    const run = this.#mcpQueue.then(
+      () => this.#callToolCorrelated(name, args, timeout),
+      () => this.#callToolCorrelated(name, args, timeout),
+    );
+    this.#mcpQueue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  /**
+   * Send one McpCall and wait for the McpResult that answers it.
+   * @private
+   */
+  async #callToolCorrelated(name, args, timeout) {
+    const correlate = this.hasFeature(MCP_CALL_ID_FEATURE);
+    // Only sent when the peer understands it: McpCallPayload is
+    // deny_unknown_fields on the Rust side, so an unsolicited call_id would
+    // make an older server reject the call outright rather than ignore it.
+    const callId = correlate ? `mcp-${++this.#mcpCallCounter}-${Date.now()}` : undefined;
+
     await this.#transport.sendControl(
-      mcpCallMsg({ tool: name, arguments: args })
+      mcpCallMsg({ tool: name, arguments: args, callId })
     );
 
     const response = await this.#waitForMessage(
       [MSG.MCP_RESULT],
       timeout,
-      `Timed out waiting for MCP tool result (${name})`
+      `Timed out waiting for MCP tool result (${name})`,
+      // A responder that echoes no call_id gets matched on type, which is
+      // the pre-correlation behaviour and all an older peer can offer.
+      callId === undefined
+        ? undefined
+        : (msg) => msg.call_id === undefined || msg.call_id === callId,
     );
 
     return response.result;
@@ -2023,10 +2078,13 @@ export class WshClient {
     }
 
     // First, check if any waiters are listening for this message type.
+    // A waiter carrying a `match` predicate only takes messages it claims,
+    // so the queue is scanned rather than shifted blindly.
     if (this.#waiters.has(type)) {
       const queue = this.#waiters.get(type);
-      if (queue.length > 0) {
-        const waiter = queue.shift();
+      for (let i = 0; i < queue.length; i++) {
+        if (queue[i].match && !queue[i].match(msg)) continue;
+        const waiter = queue.splice(i, 1)[0];
         if (queue.length === 0) this.#waiters.delete(type);
         clearTimeout(waiter.timer);
         waiter.resolve(msg);
@@ -2038,13 +2096,13 @@ export class WshClient {
     for (const [key, queue] of this.#waiters) {
       if (typeof key === 'string' && key.startsWith('multi:')) {
         for (let i = 0; i < queue.length; i++) {
-          if (queue[i].types?.includes(type)) {
-            const waiter = queue.splice(i, 1)[0];
-            if (queue.length === 0) this.#waiters.delete(key);
-            clearTimeout(waiter.timer);
-            waiter.resolve(msg);
-            return;
-          }
+          if (!queue[i].types?.includes(type)) continue;
+          if (queue[i].match && !queue[i].match(msg)) continue;
+          const waiter = queue.splice(i, 1)[0];
+          if (queue.length === 0) this.#waiters.delete(key);
+          clearTimeout(waiter.timer);
+          waiter.resolve(msg);
+          return;
         }
       }
     }
@@ -2222,7 +2280,7 @@ export class WshClient {
    * @returns {Promise<object>}
    * @private
    */
-  #waitForMessage(types, timeout, timeoutMessage) {
+  #waitForMessage(types, timeout, timeoutMessage, match) {
     const typeArr = Array.isArray(types) ? types : [types];
 
     return new Promise((resolve, reject) => {
@@ -2232,7 +2290,10 @@ export class WshClient {
         reject(new Error(timeoutMessage));
       }, timeout);
 
-      const waiter = { resolve, reject, timer, types: typeArr };
+      // `match` lets a waiter claim only the reply that belongs to it --
+      // correlation, rather than "first waiter of this type wins". Waiters
+      // without one match on type alone, as before.
+      const waiter = { resolve, reject, timer, types: typeArr, match };
 
       // For multi-type waiting, use a synthetic key.
       const key = typeArr.length === 1

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -72,7 +72,7 @@ export {
 // Session + Client
 export { WshSession } from './session.mjs';
 export { WshVirtualSessionBackend, normalizeSessionData } from './virtual-session.mjs';
-export { WshClient } from './client.mjs';
+export { WshClient, MCP_CALL_ID_FEATURE } from './client.mjs';
 
 // Key storage
 export { WshKeyStore } from './keystore.mjs';

--- a/src/mcp-bridge.mjs
+++ b/src/mcp-bridge.mjs
@@ -8,6 +8,7 @@
 
 import { MSG, mcpDiscover, mcpCall } from './messages.mjs';
 import { waitForControlMessage } from './control-listener.mjs';
+import { MCP_CALL_ID_FEATURE } from './client.mjs';
 
 /** Default timeout for MCP operations (15 seconds). */
 const MCP_TIMEOUT_MS = 15_000;
@@ -18,6 +19,16 @@ export class WshMcpBridge {
 
   /** @type {Map<string, object>} Cached tool specs: name -> { name, description, parameters } */
   #tools = new Map();
+
+  /** @type {number} Monotonically increasing counter for call_id. */
+  #callCounter = 0;
+
+  /**
+   * Tail of the serialised call chain, used only against servers that do not
+   * advertise `mcp-call-id`. Never rejects.
+   * @type {Promise<void>}
+   */
+  #queue = Promise.resolve();
 
   /**
    * @param {object} client - A `WshClient`, a `WshTransport`, or any object
@@ -85,6 +96,13 @@ export class WshMcpBridge {
    *
    * Sends an MCP_CALL message and waits for the MCP_RESULT response.
    *
+   * Safe to call concurrently. Against a server advertising `mcp-call-id`
+   * each call carries a correlation id and takes only its own reply;
+   * otherwise calls are queued one at a time, because without an id on the
+   * wire the replies are indistinguishable and `{ success, output }`
+   * normalisation strips whatever the payload might have identified itself
+   * by.
+   *
    * @param {string} toolName - Name of the tool to invoke
    * @param {object} [args={}] - Arguments to pass to the tool
    * @param {object} [opts]
@@ -103,10 +121,40 @@ export class WshMcpBridge {
       );
     }
 
-    await this.#client.sendControl(mcpCall({ tool: toolName, arguments: args }));
+    if (this.#correlates()) return this.#callOnce(toolName, args, timeout);
+
+    const run = this.#queue.then(
+      () => this.#callOnce(toolName, args, timeout),
+      () => this.#callOnce(toolName, args, timeout),
+    );
+    this.#queue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  /** True when the connected server echoes call_id. @private */
+  #correlates() {
+    return this.#client?.hasFeature?.(MCP_CALL_ID_FEATURE) === true;
+  }
+
+  /** @private */
+  async #callOnce(toolName, args, timeout) {
+    const callId = this.#correlates()
+      ? `bridge-${++this.#callCounter}-${Date.now()}`
+      : undefined;
+
+    await this.#client.sendControl(
+      mcpCall({ tool: toolName, arguments: args, callId })
+    );
 
     const response = await this._waitForMessage(
-      (msg) => msg.type === MSG.MCP_RESULT || msg.type === MSG.ERROR,
+      (msg) => {
+        // ERROR carries no call_id and cannot be attributed to one call;
+        // it is taken by whichever call is waiting.
+        if (msg.type === MSG.ERROR) return true;
+        if (msg.type !== MSG.MCP_RESULT) return false;
+        if (callId === undefined) return true;
+        return msg.call_id === undefined || msg.call_id === callId;
+      },
       timeout
     );
 

--- a/src/messages.gen.mjs
+++ b/src/messages.gen.mjs
@@ -445,15 +445,16 @@ export function mcpTools({ tools } = {}) {
   };
 }
 
-export function mcpCall({ tool, arguments: args } = {}) {
-  return { type: MSG.MCP_CALL, tool, arguments: args };
+export function mcpCall({ tool, arguments: args, callId } = {}) {
+  const m = { type: MSG.MCP_CALL, tool, arguments: args };
+  if (callId !== undefined) m.call_id = callId;
+  return m;
 }
 
-export function mcpResult({ result } = {}) {
-  return {
-    type: MSG.MCP_RESULT,
-    result,
-  };
+export function mcpResult({ result, callId } = {}) {
+  const msg = { type: MSG.MCP_RESULT, result };
+  if (callId !== undefined) msg.call_id = callId;
+  return msg;
 }
 
 export function reverseRegister({ username, capabilities = [], peerType = "host", shellBackend = "pty", supportsAttach = false, supportsReplay = false, supportsEcho = false, supportsTermSync = false, publicKey, seq, recordSignature } = {}) {

--- a/test/mcp-correlation.test.mjs
+++ b/test/mcp-correlation.test.mjs
@@ -1,0 +1,223 @@
+// test/mcp-correlation.test.mjs
+//
+// McpCall/McpResult carried no correlation field, and both client paths
+// waited on the message TYPE alone -- client.mjs's callTool() via
+// #waitForMessage([MSG.MCP_RESULT]), WshMcpBridge.call() via
+// `msg.type === MSG.MCP_RESULT`. With two calls in flight the first result
+// to arrive satisfied whichever waiter registered first, so a fast tool's
+// answer was handed to the caller waiting on a slow one. Both callers got a
+// result, neither threw, and the returned value identified no tool, so
+// nobody could detect the swap. (#32)
+//
+// The existing MCP coverage issues one call at a time against a mock that
+// answers it; one in flight is always correlated correctly. Every test here
+// therefore has at least two calls in flight at once, against a real
+// WshClient driven through the real handshake.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { WshTransport } from '../src/transport.mjs';
+import { MSG, mcpResult, serverHello } from '../src/messages.gen.mjs';
+import { WshMcpBridge } from '../src/mcp-bridge.mjs';
+
+let auth;
+let clientMod;
+try {
+  auth = await import('../src/auth.mjs');
+  clientMod = await import('../src/client.mjs');
+} catch {
+  // Web Crypto Ed25519 unavailable in this runtime.
+}
+const hasEd25519 = auth && typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined';
+
+/** Per-tool reply delays, so a later call can overtake an earlier one. */
+const DELAYS = { slow_tool: 60, fast_tool: 5 };
+
+/**
+ * An in-process server that answers each tool after its own delay.
+ *
+ * `features` decides whether it advertises mcp-call-id and echoes call_id --
+ * i.e. whether it is a server that predates the correlation field or one
+ * that implements it.
+ */
+class McpServerTransport extends WshTransport {
+  sent = [];
+
+  constructor({ features = [], echoCallId = true } = {}) {
+    super();
+    this.features = features;
+    this.echoCallId = echoCallId;
+  }
+
+  async _doConnect() {}
+  async _doClose() {}
+  async _doOpenStream() { throw new Error('not used'); }
+
+  async _doSendControl(msg) {
+    this.sent.push(msg);
+    const reply = (m, delay = 0) => setTimeout(() => this._emitControl(m), delay);
+
+    if (msg.type === MSG.HELLO) {
+      reply(serverHello({ sessionId: 'sess-mcp', features: this.features, fingerprints: [] }));
+      reply({ type: MSG.CHALLENGE, nonce: new Uint8Array(32).fill(7), session_id: 'sess-mcp' });
+    } else if (msg.type === MSG.AUTH) {
+      reply({ type: MSG.AUTH_OK });
+    } else if (msg.type === MSG.MCP_CALL) {
+      const delay = DELAYS[msg.tool] ?? 0;
+      reply(
+        mcpResult({
+          // The payload names its own tool so a swap is visible at all; the
+          // real defect is that nothing in a normal payload does.
+          result: { success: true, output: `RESULT OF ${msg.tool}` },
+          callId: this.echoCallId ? msg.call_id : undefined,
+        }),
+        delay,
+      );
+    }
+  }
+}
+
+async function connect(transport) {
+  const keyPair = await auth.generateKeyPair(true);
+  const client = new clientMod.WshClient({ transportFactories: { ws: () => transport } });
+  await client.connect('ws://test.invalid', { username: 'alice', keyPair, transport: 'ws' });
+  return client;
+}
+
+const CORRELATING = { features: ['mcp', 'mcp-call-id'] };
+const LEGACY = { features: ['mcp'] };
+
+describe('concurrent MCP calls', { skip: !hasEd25519 && 'Ed25519 not available in this runtime' }, () => {
+  it('callTool() returns each call its own result when the server correlates', async () => {
+    const transport = new McpServerTransport(CORRELATING);
+    const client = await connect(transport);
+
+    const [slow, fast] = await Promise.all([
+      client.callTool('slow_tool', {}),
+      client.callTool('fast_tool', {}),
+    ]);
+
+    assert.equal(slow.output, 'RESULT OF slow_tool');
+    assert.equal(fast.output, 'RESULT OF fast_tool');
+
+    // Both were genuinely in flight together, which is what makes the
+    // assertions above meaningful.
+    const calls = transport.sent.filter((m) => m.type === MSG.MCP_CALL);
+    assert.deepEqual(calls.map((c) => c.tool), ['slow_tool', 'fast_tool']);
+    assert.equal(new Set(calls.map((c) => c.call_id)).size, 2, 'each call needs its own id');
+    assert.ok(calls.every((c) => typeof c.call_id === 'string'));
+  });
+
+  it('callTool() is still correct against a server that does not correlate', async () => {
+    const transport = new McpServerTransport(LEGACY);
+    const client = await connect(transport);
+
+    const [slow, fast] = await Promise.all([
+      client.callTool('slow_tool', {}),
+      client.callTool('fast_tool', {}),
+    ]);
+
+    assert.equal(slow.output, 'RESULT OF slow_tool');
+    assert.equal(fast.output, 'RESULT OF fast_tool');
+  });
+
+  it('sends no call_id to a server that has not advertised the feature', async () => {
+    const transport = new McpServerTransport(LEGACY);
+    const client = await connect(transport);
+
+    await client.callTool('fast_tool', {});
+
+    const call = transport.sent.find((m) => m.type === MSG.MCP_CALL);
+    assert.ok(!('call_id' in call), 'McpCallPayload is deny_unknown_fields: an unsolicited call_id is rejected, not ignored');
+  });
+
+  it('serialises against a non-correlating server, so only one call is in flight', async () => {
+    const transport = new McpServerTransport(LEGACY);
+    const client = await connect(transport);
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const origSend = transport._doSendControl.bind(transport);
+    transport._doSendControl = async (msg) => {
+      if (msg.type === MSG.MCP_CALL) {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+      }
+      return origSend(msg);
+    };
+    transport._emitControl = new Proxy(transport._emitControl.bind(transport), {
+      apply(target, thisArg, argsList) {
+        if (argsList[0]?.type === MSG.MCP_RESULT) inFlight -= 1;
+        return Reflect.apply(target, thisArg, argsList);
+      },
+    });
+
+    await Promise.all([
+      client.callTool('slow_tool', {}),
+      client.callTool('fast_tool', {}),
+    ]);
+
+    assert.equal(maxInFlight, 1, 'without correlation, replies are indistinguishable');
+  });
+
+  it('a call whose result never arrives does not strand the next one', async () => {
+    const transport = new McpServerTransport(LEGACY);
+    const client = await connect(transport);
+
+    // Swallow the first reply entirely.
+    let swallowed = false;
+    const origSend = transport._doSendControl.bind(transport);
+    transport._doSendControl = async (msg) => {
+      if (msg.type === MSG.MCP_CALL && !swallowed) {
+        swallowed = true;
+        transport.sent.push(msg);
+        return;
+      }
+      return origSend(msg);
+    };
+
+    const first = client.callTool('slow_tool', {}, 60);
+    const second = client.callTool('fast_tool', {}, 2000);
+
+    await assert.rejects(() => first, /Timed out/);
+    assert.equal((await second).output, 'RESULT OF fast_tool', 'the queue must not stay poisoned');
+  });
+
+  it('WshMcpBridge.call() returns each call its own result', async () => {
+    const transport = new McpServerTransport(CORRELATING);
+    const client = await connect(transport);
+    const bridge = new WshMcpBridge(client);
+
+    const [slow, fast] = await Promise.all([
+      bridge.call('slow_tool', {}, { timeout: 2000 }),
+      bridge.call('fast_tool', {}, { timeout: 2000 }),
+    ]);
+
+    assert.equal(slow.output, 'RESULT OF slow_tool');
+    assert.equal(fast.output, 'RESULT OF fast_tool');
+  });
+
+  it('WshMcpBridge.call() is still correct against a non-correlating server', async () => {
+    const transport = new McpServerTransport(LEGACY);
+    const client = await connect(transport);
+    const bridge = new WshMcpBridge(client);
+
+    const [slow, fast] = await Promise.all([
+      bridge.call('slow_tool', {}, { timeout: 2000 }),
+      bridge.call('fast_tool', {}, { timeout: 2000 }),
+    ]);
+
+    assert.equal(slow.output, 'RESULT OF slow_tool');
+    assert.equal(fast.output, 'RESULT OF fast_tool');
+  });
+
+  it('ignores a McpResult whose call_id matches no outstanding call', async () => {
+    const transport = new McpServerTransport(CORRELATING);
+    const client = await connect(transport);
+
+    const pending = client.callTool('fast_tool', {}, 2000);
+    transport._emitControl(mcpResult({ result: { output: 'STRAY' }, callId: 'not-mine' }));
+
+    assert.equal((await pending).output, 'RESULT OF fast_tool');
+  });
+});


### PR DESCRIPTION
Closes #32. Pairs with erisera-code/clawser#(server half) — merge that first, or a client will simply never see the feature and keep the safe serialised path.

`McpCall`/`McpResult` carried no correlation field, and both client paths waited on the message **type** alone:

```
callTool("slow_tool") returned the result of: fast_tool
callTool("fast_tool") returned the result of: slow_tool
```

Both callers get a result, neither throws, and nothing in the returned value identifies the tool — so a caller cannot detect the swap either. `Promise.all` over `callTool` is the obvious way to use a tool bridge.

### The wire

`call_id` is optional on both messages, named after the `PolicyEval`/`PolicyResult` precedent already in this spec. Responders MUST echo it when the call carried one.

**Optional is not enough on its own.** `McpCallPayload` is `deny_unknown_fields` on the Rust side, so an older server does not *ignore* an unexpected `call_id` — it rejects the call. Sending one unconditionally would turn a wrong-result bug into a hard failure against every server predating this.

So the client sends `call_id` only when the server advertises the new `mcp-call-id` feature. Against a server that doesn't, MCP calls are **queued one at a time** on that connection: slower there, but never the wrong tool's result. That's why the fallback is serialisation rather than a documentation note.

### Client machinery

`#waitForMessage` gained an optional `match` predicate, and the dispatcher now scans its queue instead of shifting blindly, so a waiter takes only the reply it claims. A result whose `call_id` matches no outstanding call is ignored rather than resolving an unrelated caller.

### Verification

Eight tests, **all with at least two calls in flight**, against a real `WshClient` through the real handshake — the existing MCP coverage issues one call at a time, and one in flight is always correlated correctly.

| mutation | result |
|---|---|
| type-only matching (the original defect) | correlated test fails |
| remove the serialisation fallback | 3 fail |

Also pinned: no `call_id` reaches a server that didn't advertise the feature, and a timed-out call doesn't poison the queue behind it.

Full suite **553 pass, 0 fail**.
