### PR TITLE
index.d.ts had drifted from the runtime barrel

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -228,6 +228,16 @@ export const AUTH_METHOD: {
 /** Protocol version string. */
 export const PROTOCOL_VERSION: 'wsh-v1';
 
+/**
+ * ServerHello feature advertising that McpResult echoes McpCall's call_id.
+ *
+ * Compare against `WshClient.hasFeature()` before setting `callId`:
+ * McpCallPayload is `deny_unknown_fields` server-side, so sending the field
+ * to a server predating it makes the server reject the call rather than
+ * ignore the field.
+ */
+export const MCP_CALL_ID_FEATURE: 'mcp-call-id';
+
 /** A wsh protocol control message (all messages have a numeric `type`). */
 export interface WshMessage {
   type: number;
@@ -396,10 +406,14 @@ export function mcpTools(opts?: {
 export function mcpCall(opts?: {
   tool?: string;
   arguments?: Record<string, unknown>;
+  /** Correlates this call with its McpResult. Omitted from the message entirely when undefined. */
+  callId?: string;
 }): WshMessage;
 
 export function mcpResult(opts?: {
   result?: unknown;
+  /** Echoed verbatim from the McpCall this answers. */
+  callId?: string;
 }): WshMessage;
 
 // -- Message constructors (reverse) --
@@ -1377,8 +1391,21 @@ export class WshSession {
   /** Called when the remote process exits. */
   onExit: ((code: number) => void) | null;
 
-  /** Called when the session is fully closed. */
-  onClose: (() => void) | null;
+  /**
+   * Called when the session is fully closed.
+   *
+   * Receives the same value as `closeReason`: an Error for a torn-down
+   * session, null for an ordinary close.
+   */
+  onClose: ((reason: Error | null) => void) | null;
+
+  /**
+   * Why the session closed, or null for an ordinary close.
+   *
+   * A torn-down session and a clean exit are otherwise indistinguishable
+   * from the outside.
+   */
+  readonly closeReason: Error | null;
 
   /** Called when the remote peer acknowledges speculative local echo. */
   onEchoAck: ((payload: Record<string, unknown>) => void) | null;

--- a/test/exports.test.mjs
+++ b/test/exports.test.mjs
@@ -132,3 +132,36 @@ describe('wsh exports', () => {
     assert.equal(typeof SerialQueue, 'function');
   });
 });
+
+// ---------------------------------------------------------------------------
+// index.d.ts vs the runtime barrel
+//
+// src/index.d.ts is shipped in `files`, so it is the API as far as every
+// TypeScript consumer is concerned — and nothing was comparing the two. It
+// had drifted: MCP_CALL_ID_FEATURE was exported from index.mjs and absent
+// from the declarations, so the feature gate a caller needs before setting
+// `callId` was unreachable from TypeScript. The list above cannot catch this
+// class of drift because it is hand-maintained; this derives from the runtime.
+// ---------------------------------------------------------------------------
+
+describe('shipped type declarations', () => {
+  it('declares every runtime export', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const dts = readFileSync(
+      fileURLToPath(new URL('../src/index.d.ts', import.meta.url)),
+      'utf8',
+    );
+    const runtime = await import('../src/index.mjs');
+
+    const missing = Object.keys(runtime)
+      .filter(name => name !== 'default')
+      .filter(name => !new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(dts));
+
+    assert.deepEqual(
+      missing, [],
+      'these are exported at runtime but absent from src/index.d.ts, so a ' +
+      'TypeScript consumer cannot reach them',
+    );
+  });
+});


### PR DESCRIPTION
Found by a publish-readiness audit, and **the main gap is mine**: I added `MCP_CALL_ID_FEATURE` to `src/index.mjs` in #50 and never carried it into `src/index.d.ts`.

`index.d.ts` is listed in `files`, so for every TypeScript consumer it **is** the API. The feature gate a caller must check before setting `callId` was unreachable from TypeScript — and `callId` itself was missing from the `mcpCall`/`mcpResult` option types, so the whole correlation feature was untypeable.

### Also fixed, from the earlier `session.mjs` work

`WshSession.closeReason` was undeclared, and `onClose` was typed `(() => void)` while the runtime calls `this.onClose?.(this.#closeReason)`. A TypeScript caller reading the reason argument got a type error for code that works.

Typed `Error | null` rather than `StreamAuthenticationError` — that class is real but isn't exported, so naming it in the declarations would be a promise the barrel doesn't keep.

### Why nothing caught it

`test/exports.test.mjs` checks a **hand-maintained list** of expected names against the runtime. It cannot see `index.d.ts` at all, and a hand-maintained list is the same rot pattern that let the declarations go stale in the first place.

The new test derives from the runtime instead: import the barrel, assert every export name appears in `index.d.ts`.

- **157** runtime exports
- **0** missing after this change, **1** before

Removing the declaration again fails it. Full suite **554 pass, 0 fail**.
