### PR TITLE
initiateE2E dropped the peer's key exchange when it arrived first (#33)

### DIFF
--- a/src/client.mjs
+++ b/src/client.mjs
@@ -1591,6 +1591,30 @@ export class WshClient {
     this.#assertAuthenticated('initiateE2E');
     const wantHybrid = algorithm === 'X25519+ML-KEM-768';
 
+    // Register the waiter before ANY await, key generation included.
+    //
+    // Two peers establishing E2E both call this at once, and #handleControl
+    // DROPS a KEY_EXCHANGE that no waiter is listening for. Whichever side
+    // finishes its local key generation first sends its round-1 message into
+    // the other's blind window -- the other is still inside generateKey /
+    // exportKey below and has nothing registered. That message is gone, and
+    // the side that lost it then waits the full timeout for something the
+    // peer has already sent and will not send again.
+    //
+    // Registering after the crypto, or merely before sendControl, leaves the
+    // window open: measured at ~10% of runs before, and still ~5% with the
+    // waiter registered after key generation. The only safe point is here,
+    // before this function yields for the first time.
+    const peerMsgPromise = this.#waitForMessage(
+      [MSG.KEY_EXCHANGE],
+      timeout,
+      'Timed out waiting for peer key exchange'
+    );
+    // Mark it handled so a failure in the key generation or send below does
+    // not surface as an unhandled rejection when this waiter later times
+    // out. Awaiting the promise still throws normally.
+    peerMsgPromise.catch(() => {});
+
     // Generate ephemeral X25519 key pair (and, for hybrid, a fresh
     // ML-KEM-768 key pair too).
     const ephemeral = await crypto.subtle.generateKey(
@@ -1607,11 +1631,30 @@ export class WshClient {
       keyExchangeMsg({ algorithm, publicKey: localPub, sessionId, kemPublicKey: localKem?.publicKey })
     );
 
-    const peerMsg = await this.#waitForMessage(
-      [MSG.KEY_EXCHANGE],
-      timeout,
-      'Timed out waiting for peer key exchange'
-    );
+    const peerMsg = await peerMsgPromise;
+
+    // Round 2 has the same shape as round 1, so it needs the same treatment.
+    // Whether we encapsulate or decapsulate is decided entirely by data
+    // already in hand, so decide it now and register the ciphertext waiter
+    // BEFORE the derive below. Registering it inside the `else` branch, after
+    // importKey and deriveBits, let the peer's ciphertext arrive while this
+    // side was still deriving -- dropped, then a full-timeout wait for a
+    // message already sent. That surfaced as "Timed out waiting for peer
+    // ML-KEM-768 ciphertext", which retryOnKnownFlake retries and the test
+    // file attributes to a Node provider stall.
+    const hybridActive = wantHybrid && !!localKem && !!peerMsg.kem_public_key;
+    const isEncapsulator = hybridActive
+      && compareBytes(localPub, new Uint8Array(peerMsg.public_key)) < 0;
+
+    let ctMsgPromise = null;
+    if (hybridActive && !isEncapsulator) {
+      ctMsgPromise = this.#waitForMessage(
+        [MSG.KEY_EXCHANGE],
+        timeout,
+        'Timed out waiting for peer ML-KEM-768 ciphertext'
+      );
+      ctMsgPromise.catch(() => {});
+    }
 
     // Import peer's public key and derive the classical shared secret.
     const peerKey = await crypto.subtle.importKey(
@@ -1627,12 +1670,10 @@ export class WshClient {
       256
     ));
 
-    const hybridActive = wantHybrid && !!localKem && !!peerMsg.kem_public_key;
     let combinedBits = sharedBits;
 
     if (hybridActive) {
       const peerKemPublicKey = new Uint8Array(peerMsg.kem_public_key);
-      const isEncapsulator = compareBytes(localPub, new Uint8Array(peerMsg.public_key)) < 0;
 
       let kemSharedSecret;
       if (isEncapsulator) {
@@ -1640,11 +1681,7 @@ export class WshClient {
         kemSharedSecret = sharedSecret;
         await this.#transport.sendControl(keyExchangeMsg({ algorithm, sessionId, kemCiphertext: ciphertext }));
       } else {
-        const ctMsg = await this.#waitForMessage(
-          [MSG.KEY_EXCHANGE],
-          timeout,
-          'Timed out waiting for peer ML-KEM-768 ciphertext'
-        );
+        const ctMsg = await ctMsgPromise;
         kemSharedSecret = await mlKemDecapsulate(localKem.secretKeySeed, new Uint8Array(ctMsg.kem_ciphertext));
       }
 

--- a/test/client.test.mjs
+++ b/test/client.test.mjs
@@ -556,26 +556,21 @@ class E2EMockTransport extends ChallengeFirstMockTransport {
   }
 }
 
-/**
- * Retries `fn` up to `times` extra attempts if it rejects with a message
- * matching `pattern` -- used below only for the specific, root-caused
- * "Timed out waiting for peer ML-KEM-768 ciphertext" flake (see the
- * comment on the hybrid-mode test): a real protocol bug would fail
- * every attempt, including a fresh one with new transports/keys/timers,
- * so a retry can't paper over a genuine correctness problem here, only
- * the known Node-experimental-provider instability under concurrent
- * multi-process load. `node:test`'s built-in `{ retries }` test option
- * isn't available in the Node version this repo currently targets.
- */
-async function retryOnKnownFlake(fn, { times = 2, pattern = /Timed out waiting for peer ML-KEM-768 ciphertext/ } = {}) {
-  for (let attempt = 0; ; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      if (attempt >= times || !pattern.test(err.message)) throw err;
-    }
-  }
-}
+// retryOnKnownFlake used to live here, wrapping the hybrid cases against
+// "Timed out waiting for peer ML-KEM-768 ciphertext". Its rationale said the
+// stall was "an instability in Node's still-experimental provider under
+// concurrent multi-process load, not a bug in the protocol logic here" and
+// cited isolated runs of this file as "100% reliable".
+//
+// Both halves were wrong, and the retry is gone with them. Isolated runs of
+// this file failed 5 of 25 measured here, and the stall was initiateE2E
+// dropping the peer's round-2 ciphertext when it arrived before this side
+// registered a waiter for it -- a protocol-logic bug, now fixed in
+// client.mjs. With the ordering corrected the hybrid cases pass 30 of 30
+// with no retry and no run over 8s. See #33.
+//
+// If a genuine provider stall ever does appear, re-add a retry with an
+// accurate comment rather than restoring this one.
 
 describe('WshClient initiateE2E', { skip: !hasEd25519 && 'Ed25519 not available in this runtime' }, () => {
   async function connectedClient(transport) {
@@ -602,29 +597,21 @@ describe('WshClient initiateE2E', { skip: !hasEd25519 && 'Ed25519 not available 
     // exercising both role assignments across the suite's lifetime,
     // rather than only ever testing whichever role wins on one run.
     //
-    // Timeout is deliberately generous (30s, well above initiateE2E's
-    // 10s default) and the iteration count kept modest: on a machine
-    // where `node --test` runs this file concurrently with another
-    // process that's *also* exercising Node's native ML-KEM-768
-    // WebCrypto implementation (still explicitly experimental, see the
-    // ExperimentalWarning it emits), the two processes' calls can
-    // occasionally stall for many seconds -- confirmed via repeated
-    // isolated runs of just this file (100% reliable, always <100ms
-    // total) vs. paired with test/mlkem.test.mjs (occasionally hangs
-    // tens of seconds). That's an instability in Node's still-
-    // experimental provider under concurrent multi-process load, not a
-    // bug in the protocol logic here or in mlkem.mjs.
+    // The 30s timeout is kept as headroom, not as a stall allowance. It
+    // used to be justified by a theory that Node's experimental native
+    // ML-KEM-768 provider stalls under concurrent multi-process load; that
+    // was wrong. The stalls were initiateE2E dropping the peer's round-2
+    // ciphertext, and they are gone now that the waiter is registered
+    // before the derive rather than after it (#33).
     for (let i = 0; i < 3; i++) {
-      await retryOnKnownFlake(async () => {
-        const transport = new E2EMockTransport(`sess-e2e-hybrid-${i}`);
-        const client = await connectedClient(transport);
+      const transport = new E2EMockTransport(`sess-e2e-hybrid-${i}`);
+      const client = await connectedClient(transport);
 
-        const result = await client.initiateE2E(`session-hybrid-${i}`, 'X25519+ML-KEM-768', 30_000);
+      const result = await client.initiateE2E(`session-hybrid-${i}`, 'X25519+ML-KEM-768', 30_000);
 
-        assert.equal(result.hybrid, true);
-        assert.equal(transport.hybridUsed, true);
-        await assertSameAesKey(result.sharedSecret, transport.peerCombinedSecret);
-      });
+      assert.equal(result.hybrid, true);
+      assert.equal(transport.hybridUsed, true);
+      await assertSameAesKey(result.sharedSecret, transport.peerCombinedSecret);
     }
   });
 
@@ -648,11 +635,9 @@ describe('WshClient initiateE2E', { skip: !hasEd25519 && 'Ed25519 not available 
     // the hybrid client's key, then confirm the *classical* peer's
     // X25519-only-derived key fails to decrypt it (AES-GCM's auth tag
     // check throws on any key mismatch, including a valid-but-wrong key).
-    const hybridResult = await retryOnKnownFlake(async () => {
-      const hybridTransport = new E2EMockTransport('sess-e2e-diff-hybrid');
-      const hybridClient = await connectedClient(hybridTransport);
-      return hybridClient.initiateE2E('session-diff-2', 'X25519+ML-KEM-768', 30_000);
-    });
+    const hybridTransport = new E2EMockTransport('sess-e2e-diff-hybrid');
+    const hybridClient = await connectedClient(hybridTransport);
+    const hybridResult = await hybridClient.initiateE2E('session-diff-2', 'X25519+ML-KEM-768', 30_000);
 
     const classicalTransport = new E2EMockTransport('sess-e2e-diff-classical');
     const classicalClient = await connectedClient(classicalTransport);
@@ -719,6 +704,53 @@ class E2ELinkedTransport extends WshTransport {
     throw new Error('not needed for this test');
   }
 }
+
+// ── initiateE2E: the peer's round-1 message can arrive before we listen ──
+//
+// #handleControl DROPS a KEY_EXCHANGE that no waiter is listening for, and
+// initiateE2E used to register its waiter only after generating the local
+// key pair. Two peers establishing E2E both call initiateE2E at once, so
+// whichever finished key generation first sent its round-1 message into the
+// other's blind window; the loser then waited the full timeout for something
+// already sent and never repeated. Measured at ~10% of runs of the
+// EncryptedFrame integration tests, always surfacing as
+// "Timed out waiting for peer key exchange" on a CRYPTOGRAPHIC test. (#33)
+//
+// The test below does not sample that rate -- it drives the race exactly.
+// An async function body runs synchronously up to its first await, so the
+// waiter is registered (or not) before initiateE2E() returns its promise.
+// Delivering the peer message on the very next line therefore lands in the
+// blind window every time when the registration is late, and never when it
+// is early.
+
+describe('initiateE2E round-1 ordering', { skip: !hasEd25519 && 'Ed25519 not available in this runtime' }, () => {
+  it('claims a peer KEY_EXCHANGE delivered before initiateE2E has yielded even once', async () => {
+    const transport = new ChallengeFirstMockTransport('sess-race');
+    const keyPair = await auth.generateKeyPair(true);
+    const client = new clientMod.WshClient({ transportFactories: { ws: () => transport } });
+    await client.connect('ws://test.invalid', { username: 'alice', keyPair, transport: 'ws' });
+
+    // A real X25519 public key, so the derive after the wait succeeds and the
+    // only thing under test is whether the message was heard at all.
+    const peerEphemeral = await crypto.subtle.generateKey({ name: 'X25519' }, false, ['deriveBits']);
+    const peerPub = new Uint8Array(await crypto.subtle.exportKey('raw', peerEphemeral.publicKey));
+
+    // No await: initiateE2E has run only as far as its first suspension.
+    const pending = client.initiateE2E('sess-race', 'X25519', 2000);
+
+    // The peer answers in that instant -- the whole point of the race.
+    transport._emitControl({
+      type: MSG.KEY_EXCHANGE,
+      algorithm: 'X25519',
+      session_id: 'sess-race',
+      public_key: peerPub,
+    });
+
+    const result = await pending;
+    assert.equal(result.hybrid, false);
+    assert.ok(result.sharedSecret, 'a dropped round-1 message shows up here as a timeout');
+  });
+});
 
 describe('EncryptedFrame end-to-end integration', { skip: !hasEd25519 && 'Ed25519 not available in this runtime' }, () => {
   it('two real WshClient/WshSession pairs exchange sealed data that an eavesdropper on the raw wire cannot read', async () => {


### PR DESCRIPTION
Closes #33. This turned out to be a real protocol bug, not test flakiness.

`#handleControl` **drops** a `KEY_EXCHANGE` that no waiter is listening for, and `initiateE2E` registered its waiter only *after* generating the local key pair. Two peers establishing E2E both call `initiateE2E` at once, so whichever finished key generation first sent its round-1 message into the other's blind window. That message is gone and is never repeated — so the side that lost it waited the full timeout for something the peer had already sent.

Same shape one round later: the decapsulator registered its ciphertext waiter inside the `else` branch, after `importKey` and `deriveBits`, while the encapsulator raced toward its send.

Both waiters are now registered before the awaits they were racing.

### What the issue got wrong

It reports ~5% suite flakiness and says `client.test.mjs` "passes every time (3/3)" in isolation. **Measured over 25 isolated runs: 5 failed.** The 3-run sample was too small, and it pointed the diagnosis at cross-process contention that isn't the cause.

### What the code comment got wrong

The hybrid test's comment attributed the 30s stalls to *"an instability in Node's still-experimental provider under concurrent multi-process load, not a bug in the protocol logic here"*, citing isolated runs as "100% reliable, always <100ms".

Both halves were wrong. It was protocol logic, and `retryOnKnownFlake` existed to retry it away. Both are removed — with the ordering fixed, the hybrid cases pass **30/30 with no retry and no run over 8s**. The comment now says what actually happened.

### Two wrong turns, recorded so nobody repeats them

`WSH_MLKEM_BACKEND=noble` gave 25/25, and `UV_THREADPOOL_SIZE=16` and `64` each gave 25/25 — which looked like ML-KEM threadpool starvation. Both were luck:

- a pool sweep across 2, 3, 4, 5, 6, 8, 12 showed failures at **every** size with no trend
- running **only** the EncryptedFrame tests, with no ML-KEM test executing at all, still failed 3/15
- a direct starvation probe found X25519 at **1 ms** under 8 concurrent ML-KEM operations
- every ML-KEM primitive timed under a millisecond across 60 iterations

Neither ML-KEM nor the threadpool is involved.

### Verification

The regression test doesn't sample a rate — it drives the race. An async function body runs synchronously to its first `await`, so the waiter is registered (or not) before `initiateE2E()` returns its promise; delivering the peer message on the very next line lands in the blind window every time when registration is late, and never when it's early.

It fails deterministically against the original order **and** against registering merely before `sendControl` — which was my own first, insufficient fix.

| | before | after |
|---|---|---|
| round 1, EncryptedFrame tests | ~10% fail | **0/60** |
| round 2, whole file, no retry | 5/30 fail, 5 slow | **30/30, 0 slow** |
| full `npm test` | 5/15 runs over 8s | **15/15, 0 slow** |

Full suite **554 pass, 0 fail**.
